### PR TITLE
fix: make `storage_selector` required

### DIFF
--- a/cmd/omni-infra-provider-proxmox/data/schema.json
+++ b/cmd/omni-infra-provider-proxmox/data/schema.json
@@ -30,6 +30,7 @@
   "required": [
     "cores",
     "memory",
-    "disk_size"
+    "disk_size",
+    "storage_selector"
   ]
 }


### PR DESCRIPTION
As the provider can't create VMs without it.
Fixes: https://github.com/siderolabs/omni-infra-provider-proxmox/issues/4