### PR TITLE
fix: use unique patch name for the hostname patches

### DIFF
--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -159,7 +159,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			return provision.NewRetryInterval(time.Second)
 		}),
 		provision.NewStep("configureHostname", func(ctx context.Context, _ *zap.Logger, pctx provision.Context[*resources.Machine]) error {
-			return pctx.CreateConfigPatch(ctx, "hostname", []byte(fmt.Sprintf(`machine:
+			return pctx.CreateConfigPatch(ctx, "000-hostname-%s"+pctx.GetRequestID(), []byte(fmt.Sprintf(`machine:
   network:
     hostname: %s`, pctx.GetRequestID())))
 		}),


### PR DESCRIPTION
The patch name should be unique per machine.