### PR TITLE
Feature/advanced vm options

### DIFF
--- a/cmd/omni-infra-provider-proxmox/data/schema.json
+++ b/cmd/omni-infra-provider-proxmox/data/schema.json
@@ -3,11 +3,13 @@
   "properties": {
     "cores": {
       "type": "integer",
-      "minimum": 1
+      "minimum": 1,
+      "description": "Number of CPU cores per socket"
     },
     "sockets": {
       "type": "integer",
-      "minimum": 1
+      "minimum": 1,
+      "description": "Number of CPU sockets"
     },
     "storage_selector": {
       "type": "string",
@@ -15,16 +17,17 @@
     },
     "node": {
       "type": "string",
-      "description": "Run the VM on a specific node"
+      "description": "Run the VM on a specific Proxmox node"
     },
     "memory": {
       "type": "integer",
-      "minimum": 2048
+      "minimum": 2048,
+      "description": "Memory in MB"
     },
     "disk_size": {
       "type": "integer",
       "minimum": 5,
-      "description": "In GB"
+      "description": "Disk size in GB"
     },
     "network_bridge": {
       "type": "string",
@@ -33,14 +36,180 @@
     "vlan": {
       "type": "integer",
       "minimum": 0,
-      "description": "VLAN tag, set to 0 for none"
+      "description": "VLAN tag for primary NIC, set to 0 for none"
+    },
+    "disk_ssd": {
+      "type": "boolean",
+      "description": "Enable SSD emulation (ssd=1) for better performance on SSD/NVMe storage"
+    },
+    "disk_discard": {
+      "type": "boolean",
+      "description": "Enable TRIM/discard support for thin-provisioned storage"
+    },
+    "disk_iothread": {
+      "type": "boolean",
+      "description": "Enable dedicated IO thread for better disk performance"
+    },
+    "disk_cache": {
+      "type": "string",
+      "enum": [
+        "none",
+        "writethrough",
+        "writeback",
+        "directsync",
+        "unsafe"
+      ],
+      "description": "Disk cache mode. Use 'none' for best performance with battery-backed storage"
+    },
+    "disk_aio": {
+      "type": "string",
+      "enum": [
+        "native",
+        "threads",
+        "io_uring"
+      ],
+      "description": "Async IO mode. Use 'io_uring' for best performance on modern kernels"
+    },
+    "cpu_type": {
+      "type": "string",
+      "description": "CPU type. Use 'host' for GPU passthrough/HPC, or 'x86-64-v2-AES' (default) for compatibility"
+    },
+    "machine_type": {
+      "type": "string",
+      "enum": [
+        "q35",
+        "i440fx"
+      ],
+      "description": "Machine type. Use 'q35' for GPU passthrough (native PCIe support)"
+    },
+    "numa": {
+      "type": "boolean",
+      "description": "Enable NUMA topology for better memory locality on multi-socket systems"
+    },
+    "hugepages": {
+      "type": "string",
+      "enum": [
+        "2MB",
+        "1GB"
+      ],
+      "description": "Enable hugepages for reduced TLB misses. Use '1GB' for GPU/HPC workloads"
+    },
+    "balloon": {
+      "type": "boolean",
+      "description": "Enable memory ballooning. Set to false for GPU passthrough or hugepages"
+    },
+    "additional_nics": {
+      "type": "array",
+      "description": "Additional network interfaces (e.g., for storage networks)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "bridge": {
+            "type": "string",
+            "description": "Network bridge (e.g., vmbr1)"
+          },
+          "vlan": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Optional VLAN tag"
+          },
+          "firewall": {
+            "type": "boolean",
+            "description": "Enable Proxmox firewall for this NIC"
+          }
+        },
+        "required": [
+          "bridge"
+        ]
+      }
+    },
+    "pci_devices": {
+      "type": "array",
+      "description": "PCI devices to pass through using Proxmox Resource Mappings",
+      "items": {
+        "type": "object",
+        "properties": {
+          "mapping": {
+            "type": "string",
+            "description": "Proxmox Resource Mapping name (e.g., nvidia-gpu-1)"
+          },
+          "pcie": {
+            "type": "boolean",
+            "description": "Use PCIe mode instead of PCI (recommended for GPUs)"
+          },
+          "primary_gpu": {
+            "type": "boolean",
+            "description": "Set as primary GPU (x-vga=1) for display output"
+          },
+          "rombar": {
+            "type": "boolean",
+            "description": "Enable ROM BAR for device ROM"
+          }
+        },
+        "required": [
+          "mapping"
+        ]
+      }
+    },
+    "additional_disks": {
+      "type": "array",
+      "description": "Additional disks to attach to the VM (scsi1, scsi2, etc.)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "disk_size": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Disk size in GB"
+          },
+          "storage_selector": {
+            "type": "string",
+            "description": "CEL expression for selecting VM disk image storage for this disk"
+          },
+          "disk_ssd": {
+            "type": "boolean",
+            "description": "Enable SSD emulation for this disk"
+          },
+          "disk_discard": {
+            "type": "boolean",
+            "description": "Enable TRIM/discard support for this disk"
+          },
+          "disk_iothread": {
+            "type": "boolean",
+            "description": "Enable dedicated IO thread for this disk"
+          },
+          "disk_cache": {
+            "type": "string",
+            "enum": [
+              "none",
+              "writethrough",
+              "writeback",
+              "directsync",
+              "unsafe"
+            ],
+            "description": "Disk cache mode for this disk"
+          },
+          "disk_aio": {
+            "type": "string",
+            "enum": [
+              "native",
+              "threads",
+              "io_uring"
+            ],
+            "description": "Async IO mode for this disk"
+          }
+        },
+        "required": [
+          "disk_size",
+          "storage_selector"
+        ]
+      }
     }
   },
   "required": [
     "cores",
     "memory",
     "disk_size",
-    "storage_selector",
-    "network_bridge"
+    "storage_selector"
   ]
 }

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -6,12 +6,51 @@ package provider
 
 // Data is the provider custom machine config.
 type Data struct {
-	Node            string `yaml:"node,omitempty"`
-	StorageSelector string `yaml:"storage_selector,omitempty"`
-	NetworkBridge   string `yaml:"network_bridge"`
-	Cores           int    `yaml:"cores"`
+	Balloon         *bool            `yaml:"balloon,omitempty"`
+	Node            string           `yaml:"node,omitempty"`
+	StorageSelector string           `yaml:"storage_selector,omitempty"`
+	NetworkBridge   string           `yaml:"network_bridge"`
+	Hugepages       string           `yaml:"hugepages,omitempty"`
+	MachineType     string           `yaml:"machine_type,omitempty"`
+	CPUType         string           `yaml:"cpu_type,omitempty"`
+	DiskAIO         string           `yaml:"disk_aio,omitempty"`
+	DiskCache       string           `yaml:"disk_cache,omitempty"`
+	AdditionalDisks []AdditionalDisk `yaml:"additional_disks,omitempty"`
+	AdditionalNICs  []AdditionalNIC  `yaml:"additional_nics,omitempty"`
+	PCIDevices      []PCIDevice      `yaml:"pci_devices,omitempty"`
+	Vlan            uint64           `yaml:"vlan"`
+	Memory          uint64           `yaml:"memory"`
+	Sockets         int              `yaml:"sockets"`
+	DiskSize        int              `yaml:"disk_size"`
+	Cores           int              `yaml:"cores"`
+	DiskIOThread    bool             `yaml:"disk_iothread,omitempty"`
+	NUMA            bool             `yaml:"numa,omitempty"`
+	DiskDiscard     bool             `yaml:"disk_discard,omitempty"`
+	DiskSSD         bool             `yaml:"disk_ssd,omitempty"`
+}
+
+// AdditionalDisk represents an additional disk configuration.
+type AdditionalDisk struct {
+	StorageSelector string `yaml:"storage_selector"`
+	DiskCache       string `yaml:"disk_cache,omitempty"`
+	DiskAIO         string `yaml:"disk_aio,omitempty"`
 	DiskSize        int    `yaml:"disk_size"`
-	Sockets         int    `yaml:"sockets"`
-	Memory          uint64 `yaml:"memory"`
-	Vlan            uint64 `yaml:"vlan"`
+	DiskSSD         bool   `yaml:"disk_ssd,omitempty"`
+	DiskDiscard     bool   `yaml:"disk_discard,omitempty"`
+	DiskIOThread    bool   `yaml:"disk_iothread,omitempty"`
+}
+
+// PCIDevice represents a PCI device passthrough configuration using Proxmox Resource Mappings.
+type PCIDevice struct {
+	Mapping    string `yaml:"mapping"`               // Resource mapping name (e.g., nvidia-gpu-1)
+	PCIExpress bool   `yaml:"pcie,omitempty"`        // Use PCIe instead of PCI (recommended for GPUs)
+	PrimaryGPU bool   `yaml:"primary_gpu,omitempty"` // Set as primary GPU (x-vga=1)
+	ROMBar     bool   `yaml:"rombar,omitempty"`      // Enable ROM BAR (default true, set false to disable)
+}
+
+// AdditionalNIC represents an additional network interface configuration.
+type AdditionalNIC struct {
+	Bridge   string `yaml:"bridge"`             // Network bridge (e.g., vmbr1)
+	Vlan     uint64 `yaml:"vlan,omitempty"`     // Optional VLAN tag
+	Firewall bool   `yaml:"firewall,omitempty"` // Enable firewall (default: false for storage networks)
 }


### PR DESCRIPTION
# PR Notes: Advanced Proxmox VM Provisioning Enhancements

This pull request significantly expands and refines the Proxmox VM provisioning capabilities by introducing advanced configuration options for disk, CPU, memory, PCI passthrough, and network interfaces. It enhances the schema and provider logic to support high-performance workloads, GPU/HPC scenarios, and more flexible VM setups.

## 🚀 Key Improvements

### 1. Schema and Data Model Enhancements
Extended the VM configuration schema (`schema.json` and `Data` struct) to support:
*   **Advanced Disk Options**: SSD emulation, TRIM/discard, IO thread, cache, and AIO modes.
*   **Performance Optimizations**: CPU type, machine type (q35/i440fx), NUMA, hugepages, and memory ballooning control.
*   **Hardware Passthrough**: Support for multiple PCI devices using Proxmox Resource Mappings.
*   **Advanced Networking**: Support for multiple additional NICs with VLAN tagging and firewall control.
*   **Multi-Disk Provisioning**: Ability to attach multiple additional disks with independent storage selection.

### 2. Provisioning Logic Improvements
*   **Dynamic VM Construction**: Refactored logic to dynamically build Proxmox VM options based on the provided hardware specs.
*   **Smart Defaults**: Implemented sensible defaults (e.g., `vmbr0` for networks, `x86-64-v2-AES` for CPU) to ensure backward compatibility and "just works" behavior for simple configs.
*   **Hardware Mapping**: Integrated Proxmox-specific formats for hugepages, ballooning, and PCI device options.

### 3. Storage Selection Refactoring
*   **`pickStorage` Helper**: Extracted storage selection into a reusable helper function utilizing CEL expressions, used for both primary and additional disks.
*   **Consistency**: Ensures consistent storage selection logic across all disk attachments.

### 4. Documentation and Usability
*   **Schema Descriptions**: Expanded JSON schema descriptions to provide in-CLI guidance for all new fields.
*   **Validation**: stricter validation for performance modes (enum guarding cache and AIO modes).

---

## 🛠 MachineClass Examples

### High-Performance GPU Worker
*Showcases: `cpu_type: host`, `q35`, PCI passthrough, NUMA, and Disk optimizations.*

```yaml
metadata:
  id: proxmox-gpu-worker
spec:
  autoprovision:
    providerid: proxmox
    providerdata: |
      cores: 24
      memory: 480000
      storage_selector: name == "ssdpool"
      cpu_type: host
      machine_type: q35
      numa: true
      balloon: false
      pci_devices:
        - mapping: nvidia-rtx-4090
          pcie: true
      disk_ssd: true
      disk_aio: io_uring
      disk_cache: none
```

### Multi-Disk Storage Node
*Showcases: `additional_disks` and storage-specific performance settings.*

```yaml
metadata:
  id: proxmox-storage-node
spec:
  autoprovision:
    providerid: proxmox
    providerdata: |
      cores: 16
      memory: 64000
      disk_size: 100
      storage_selector: name == "fastpool"
      additional_disks:
        - disk_size: 500
          storage_selector: name == "nvme-pool"
          disk_ssd: true
          disk_iothread: true
          disk_aio: io_uring
        - disk_size: 1000
          storage_selector: name == "hdd-archive"
          disk_cache: writeback
```

### Multi-Homed Network Worker
*Showcases: `additional_nics`, `vlan` tagging, and `discard` support.*

```yaml
metadata:
  id: proxmox-worker-multi-net
spec:
  autoprovision:
    providerid: proxmox
    providerdata: |
      cores: 8
      memory: 32000
      disk_size: 200
      storage_selector: name == "ssdpool"
      disk_discard: true
      vlan: 10
      additional_nics:
        - bridge: vmbr1 # Storage LAN
          firewall: false
        - bridge: vmbr2 # Isolated App LAN
          vlan: 20
```

---

## 📋 Field Summary Reference

| Category | Fields |
| :--- | :--- |
| **Compute** | `cores`, `sockets`, `memory`, `cpu_type`, `machine_type`, `numa`, `hugepages`, `balloon` |
| **Storage** | `disk_size`, `storage_selector`, `disk_ssd`, `disk_discard`, `disk_iothread`, `disk_cache`, `disk_aio`, `additional_disks` |
| **Network** | `network_bridge`, `vlan`, `additional_nics` |
| **PCI** | `pci_devices` |
