### PR TITLE
feat: support vm tags and pool in machine class config

### DIFF
--- a/api/specs/specs.pb.go
+++ b/api/specs/specs.pb.go
@@ -36,6 +36,7 @@ type MachineSpec struct {
 	VmCreateTask     string                 `protobuf:"bytes,7,opt,name=vm_create_task,json=vmCreateTask,proto3" json:"vm_create_task,omitempty"`
 	VmStartTask      string                 `protobuf:"bytes,8,opt,name=vm_start_task,json=vmStartTask,proto3" json:"vm_start_task,omitempty"`
 	Vmid             int32                  `protobuf:"varint,11,opt,name=vmid,proto3" json:"vmid,omitempty"`
+	Pool             string                 `protobuf:"bytes,12,opt,name=pool,proto3" json:"pool,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -133,11 +134,18 @@ func (x *MachineSpec) GetVmid() int32 {
 	return 0
 }
 
+func (x *MachineSpec) GetPool() string {
+	if x != nil {
+		return x.Pool
+	}
+	return ""
+}
+
 var File_specs_specs_proto protoreflect.FileDescriptor
 
 const file_specs_specs_proto_rawDesc = "" +
 	"\n" +
-	"\x11specs/specs.proto\x12\bemuspecs\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\xa1\x02\n" +
+	"\x11specs/specs.proto\x12\bemuspecs\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\xb5\x02\n" +
 	"\vMachineSpec\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x1c\n" +
 	"\tschematic\x18\x02 \x01(\tR\tschematic\x12#\n" +
@@ -147,7 +155,8 @@ const file_specs_specs_proto_rawDesc = "" +
 	"\x12volume_upload_task\x18\x06 \x01(\tR\x10volumeUploadTask\x12$\n" +
 	"\x0evm_create_task\x18\a \x01(\tR\fvmCreateTask\x12\"\n" +
 	"\rvm_start_task\x18\b \x01(\tR\vvmStartTask\x12\x12\n" +
-	"\x04vmid\x18\v \x01(\x05R\x04vmidB=Z;github.com/siderolabs/omni-infra-provider-proxmox/api/specsb\x06proto3"
+	"\x04vmid\x18\v \x01(\x05R\x04vmid\x12\x12\n" +
+	"\x04pool\x18\f \x01(\tR\x04poolB=Z;github.com/siderolabs/omni-infra-provider-proxmox/api/specsb\x06proto3"
 
 var (
 	file_specs_specs_proto_rawDescOnce sync.Once

--- a/api/specs/specs.proto
+++ b/api/specs/specs.proto
@@ -17,4 +17,5 @@ message MachineSpec {
   string vm_create_task = 7;
   string vm_start_task = 8;
   int32 vmid = 11;
+  string pool = 12;
 }

--- a/api/specs/specs_vtproto.pb.go
+++ b/api/specs/specs_vtproto.pb.go
@@ -34,6 +34,7 @@ func (m *MachineSpec) CloneVT() *MachineSpec {
 	r.VmCreateTask = m.VmCreateTask
 	r.VmStartTask = m.VmStartTask
 	r.Vmid = m.Vmid
+	r.Pool = m.Pool
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -78,6 +79,9 @@ func (this *MachineSpec) EqualVT(that *MachineSpec) bool {
 	if this.Vmid != that.Vmid {
 		return false
 	}
+	if this.Pool != that.Pool {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -117,6 +121,13 @@ func (m *MachineSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Pool) > 0 {
+		i -= len(m.Pool)
+		copy(dAtA[i:], m.Pool)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Pool)))
+		i--
+		dAtA[i] = 0x62
 	}
 	if m.Vmid != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Vmid))
@@ -222,6 +233,10 @@ func (m *MachineSpec) SizeVT() (n int) {
 	}
 	if m.Vmid != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Vmid))
+	}
+	l = len(m.Pool)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -531,6 +546,38 @@ func (m *MachineSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pool", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Pool = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/cmd/omni-infra-provider-proxmox/data/schema.json
+++ b/cmd/omni-infra-provider-proxmox/data/schema.json
@@ -98,6 +98,18 @@
       "type": "boolean",
       "description": "Enable memory ballooning. Set to false for GPU passthrough or hugepages"
     },
+    "pool": {
+      "type": "string",
+      "description": "Proxmox resource pool"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Proxmox VM tags"
+    },
     "additional_nics": {
       "type": "array",
       "description": "Additional network interfaces (e.g., for storage networks)",

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -15,9 +15,11 @@ type Data struct {
 	CPUType         string           `yaml:"cpu_type,omitempty"`
 	DiskAIO         string           `yaml:"disk_aio,omitempty"`
 	DiskCache       string           `yaml:"disk_cache,omitempty"`
+	Pool            string           `yaml:"pool,omitempty"`
 	AdditionalDisks []AdditionalDisk `yaml:"additional_disks,omitempty"`
 	AdditionalNICs  []AdditionalNIC  `yaml:"additional_nics,omitempty"`
 	PCIDevices      []PCIDevice      `yaml:"pci_devices,omitempty"`
+	Tags            []string         `yaml:"tags,omitempty"`
 	Vlan            uint64           `yaml:"vlan"`
 	Memory          uint64           `yaml:"memory"`
 	Sockets         int              `yaml:"sockets"`

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -9,3 +9,11 @@ type NodeStatus = nodeStatus
 func PickNode(nodes []NodeStatus) NodeStatus {
 	return pickNode(nodes)
 }
+
+func BuildTagsOption(userTags []string, machineRequestSet string) (string, bool) {
+	return buildTagsOption(userTags, machineRequestSet)
+}
+
+func PoolCreateDecision(exists bool, poolID, machineRequestSet string) (bool, error) {
+	return poolCreateDecision(exists, poolID, machineRequestSet)
+}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -30,13 +30,17 @@ import (
 	"github.com/siderolabs/omni-infra-provider-proxmox/internal/pkg/provider/resources"
 )
 
-const machineRequestTagPrefix = "machine-request."
+const (
+	machineRequestTagPrefix = "machine-request."
+	poolComment             = "managed by omni-infra-provider-proxmox"
+)
 
 // Provisioner implements Talos emulator infra provider.
 type Provisioner struct {
 	proxmoxClient         *proxmox.Client
 	pendingISODownloads   map[string]string
 	pendingISODownloadsMu sync.Mutex
+	poolMu                sync.Mutex
 }
 
 // NewProvisioner creates a new provisioner.
@@ -377,14 +381,28 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				},
 			}
 
-			if machineRequestSet, ok := pctx.GetMachineRequestSetID(); ok {
-				vmOptions = append(
-					vmOptions,
-					proxmox.VirtualMachineOption{
-						Name:  "tags",
-						Value: machineRequestTagPrefix + machineRequestSet,
-					},
-				)
+			machineRequestSet, _ := pctx.GetMachineRequestSetID()
+			if value, ok := buildTagsOption(data.Tags, machineRequestSet); ok {
+				vmOptions = append(vmOptions, proxmox.VirtualMachineOption{
+					Name:  "tags",
+					Value: value,
+				})
+			}
+
+			if value := cmp.Or(data.Pool, machineRequestSet); value != "" {
+				p.poolMu.Lock()
+				defer p.poolMu.Unlock()
+
+				if err = p.ensurePool(ctx, logger, value, machineRequestSet); err != nil {
+					return err
+				}
+
+				pctx.State.TypedSpec().Value.Pool = value
+
+				vmOptions = append(vmOptions, proxmox.VirtualMachineOption{
+					Name:  "pool",
+					Value: value,
+				})
 			}
 
 			// Primary disk is always scsi0. Additional disks start from scsi1.
@@ -609,7 +627,113 @@ func (p *Provisioner) Deprovision(ctx context.Context, logger *zap.Logger, machi
 		return err
 	}
 
+	if pool := machine.TypedSpec().Value.Pool; pool != "" {
+		p.cleanupPool(ctx, logger, pool)
+	}
+
 	return nil
+}
+
+// User tags come first so the tags string is stable across reconciles.
+func buildTagsOption(userTags []string, machineRequestSet string) (string, bool) {
+	tags := make([]string, 0, len(userTags)+1)
+	tags = append(tags, userTags...)
+
+	if machineRequestSet != "" {
+		tags = append(tags, machineRequestTagPrefix+machineRequestSet)
+	}
+
+	if len(tags) == 0 {
+		return "", false
+	}
+
+	return strings.Join(tags, ";"), true
+}
+
+func poolCreateDecision(exists bool, poolID, machineRequestSet string) (bool, error) {
+	if exists {
+		return false, nil
+	}
+
+	if poolID == machineRequestSet {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("proxmox pool %q does not exist; create it in Proxmox or leave \"pool\" empty to use the machine request set id", poolID)
+}
+
+// List + search instead of Pool(id): go-proxmox flattens missing-pool 404 into a generic 500.
+func (p *Provisioner) findPoolInList(ctx context.Context, poolID string) (comment string, exists bool, err error) {
+	pools, err := p.proxmoxClient.Pools(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to list proxmox pools: %w", err)
+	}
+
+	for _, pool := range pools {
+		if pool.PoolID == poolID {
+			return pool.Comment, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+func (p *Provisioner) ensurePool(ctx context.Context, logger *zap.Logger, poolID, machineRequestSet string) error {
+	_, exists, err := p.findPoolInList(ctx, poolID)
+	if err != nil {
+		return err
+	}
+
+	create, err := poolCreateDecision(exists, poolID, machineRequestSet)
+	if err != nil {
+		return err
+	}
+
+	if !create {
+		return nil
+	}
+
+	logger.Info("creating proxmox pool", zap.String("pool", poolID))
+
+	return p.proxmoxClient.NewPool(ctx, poolID, poolComment)
+}
+
+// Errors are swallowed on purpose: pool cleanup must not fail deprovision.
+func (p *Provisioner) cleanupPool(ctx context.Context, logger *zap.Logger, poolID string) {
+	p.poolMu.Lock()
+	defer p.poolMu.Unlock()
+
+	comment, exists, err := p.findPoolInList(ctx, poolID)
+	if err != nil {
+		logger.Warn("failed to list proxmox pools during cleanup", zap.String("pool", poolID), zap.Error(err))
+
+		return
+	}
+
+	if !exists || comment != poolComment {
+		return
+	}
+
+	// List doesn't return members, so hit the detail endpoint before deciding
+	// whether to delete.
+	detail, err := p.proxmoxClient.Pool(ctx, poolID)
+	if err != nil {
+		logger.Warn("failed to load proxmox pool detail during cleanup", zap.String("pool", poolID), zap.Error(err))
+
+		return
+	}
+
+	if detail.Comment != poolComment || len(detail.Members) != 0 {
+		return
+	}
+
+	if err := detail.Delete(ctx); err != nil {
+		logger.Warn("failed to delete proxmox pool", zap.String("pool", poolID), zap.Error(err))
+
+		return
+	}
+
+	logger.Info("deleted empty proxmox pool", zap.String("pool", poolID))
 }
 
 func (p *Provisioner) pickStorage(ctx context.Context, node *proxmox.Node, selector string) (string, error) {

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/siderolabs/omni-infra-provider-proxmox/internal/pkg/provider"
 )
 
+const talosWorkers = "talos-workers"
+
 func TestPickNode(t *testing.T) {
 	const (
 		nodeA = "NodeA"
@@ -77,6 +79,96 @@ func TestPickNode(t *testing.T) {
 
 			// Assert
 			require.Equal(t, tt.expected, result.Name)
+		})
+	}
+}
+
+func TestPoolCreateDecision(t *testing.T) {
+	tests := []struct {
+		name              string
+		poolID            string
+		machineRequestSet string
+		exists            bool
+		expectedCreate    bool
+		expectedErr       bool
+	}{
+		{
+			name:              "Pool exists: no-op",
+			poolID:            "my-pool",
+			machineRequestSet: talosWorkers,
+			exists:            true,
+			expectedCreate:    false,
+		},
+		{
+			name:              "Pool absent, matches machine request set: create",
+			poolID:            talosWorkers,
+			machineRequestSet: talosWorkers,
+			expectedCreate:    true,
+		},
+		{
+			name:              "Pool absent, user-specified: refuse",
+			poolID:            "gpu-pool",
+			machineRequestSet: talosWorkers,
+			expectedErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			create, err := provider.PoolCreateDecision(tt.exists, tt.poolID, tt.machineRequestSet)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+				require.False(t, create)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedCreate, create)
+		})
+	}
+}
+
+func TestBuildTagsOption(t *testing.T) {
+	tests := []struct {
+		name              string
+		machineRequestSet string
+		expectedValue     string
+		userTags          []string
+		expectedOk        bool
+	}{
+		{
+			name:       "No user tags, no request set",
+			expectedOk: false,
+		},
+		{
+			name:              "Request set only",
+			machineRequestSet: talosWorkers,
+			expectedValue:     "machine-request.talos-workers",
+			expectedOk:        true,
+		},
+		{
+			name:          "User tags only",
+			userTags:      []string{"talos-node", "prod"},
+			expectedValue: "talos-node;prod",
+			expectedOk:    true,
+		},
+		{
+			name:              "User tags first, internal tag last",
+			userTags:          []string{"talos-node", "prod"},
+			machineRequestSet: talosWorkers,
+			expectedValue:     "talos-node;prod;machine-request.talos-workers",
+			expectedOk:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := provider.BuildTagsOption(tt.userTags, tt.machineRequestSet)
+
+			require.Equal(t, tt.expectedOk, ok)
+			require.Equal(t, tt.expectedValue, value)
 		})
 	}
 }


### PR DESCRIPTION
Add `tags` and `pool` to the providerdata of a MachineClass so users can attach Proxmox VM tags and assign VMs to a resource pool at provisioning time.

Tags are joined with the existing internal `machine-request.<set-id>` tag so the node-distribution logic in `pickNode` keeps working.

Fixes: https://github.com/siderolabs/omni-infra-provider-proxmox/issues/53