### PR TITLE
feat: skip offline nodes during provisioning to prevent API errors

### DIFF
--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -94,6 +94,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			nodeInfoList := make([]nodeStatus, 0, len(nodes))
 
 			for _, node := range nodes {
+				// Skip nodes that are not online to avoid Proxmox API errors
+				if node.Status != "online" {
+					logger.Debug("skipping offline node", zap.String("node", node.Node), zap.String("status", node.Status))
+
+					continue
+				}
+
 				var ns nodeStatus
 
 				ns.Name = node.Node
@@ -118,6 +125,10 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				}
 
 				nodeInfoList = append(nodeInfoList, ns)
+			}
+
+			if len(nodeInfoList) == 0 {
+				return fmt.Errorf("no online nodes available for provisioning")
 			}
 
 			pickedNode := pickNode(nodeInfoList)


### PR DESCRIPTION
This PR enables the provider to skip offline nodes within a Proxmox Cluster.
Currently the provisioning of workers will fail if a node is offline, with this fix all offline nodes are being skipped.

<details>
Log of the error:
> omni-infra-provider-proxmox-1  | {"level":"info","ts":1779221695.0373151,"caller":"controllers/provision.go:309","msg":"running provision step","controller":"proxmox.ProvisionController","namespace":"infra-provider","type":"MachineRequests.omni.sidero.dev","id":"talos-default-workers-zmlr5b","job":"reconcile","step":"pickNode"}
omni-infra-provider-proxmox-1  | {"level":"error","ts":1779221698.2150989,"caller":"controllers/provision.go:339","msg":"machine provision failed","controller":"proxmox.ProvisionController","namespace":"infra-provider","type":"MachineRequests.omni.sidero.dev","id":"talos-default-workers-zmlr5b","job":"reconcile","error":"**failed to get node \"pve3\", unexpected end of JSON input**","step":"pickNode","stacktrace":"github.com/siderolabs/omni/client/pkg/infra/controllers.(*ProvisionController[...]).reconcileRunning\n\t/go/pkg/mod/github.com/siderolabs/omni/client@v1.6.5/pkg/infra/controllers/provision.go:339\ngithub.com/siderolabs/omni/client/pkg/infra/controllers.(*ProvisionController[...]).Reconcile\n\t/go/pkg/mod/github.com/siderolabs/omni/client@v1.6.5/pkg/infra/controllers/provision.go:221\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/qruntime.(*Adapter).runOnce\n\t/go/pkg/mod/github.com/cosi-project/runtime@v1.14.1/pkg/controller/runtime/internal/qruntime/qruntime.go:353\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/qruntime.(*Adapter).runReconcile.func1\n\t/go/pkg/mod/github.com/cosi-project/runtime@v1.14.1/pkg/controller/runtime/internal/qruntime/qruntime.go:260\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/qruntime.(*Adapter).runReconcile\n\t/go/pkg/mod/github.com/cosi-project/runtime@v1.14.1/pkg/controller/runtime/internal/qruntime/qruntime.go:320\ngithub.com/cosi-project/runtime/pkg/controller/runtime/internal/qruntime.(*Adapter).Run.func2\n\t/go/pkg/mod/github.com/cosi-project/runtime@v1.14.1/pkg/controller/runtime/internal/qruntime/qruntime.go:146\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93"}
</details>