### PR TITLE
feat: configurable firewall on primary NIC via network_firewall

### DIFF
--- a/cmd/omni-infra-provider-proxmox/data/schema.json
+++ b/cmd/omni-infra-provider-proxmox/data/schema.json
@@ -38,6 +38,10 @@
       "minimum": 0,
       "description": "VLAN tag for primary NIC, set to 0 for none"
     },
+    "network_firewall": {
+      "type": "boolean",
+      "description": "Enable per-VM firewall (fwbr) on primary NIC. Defaults to true. Set false when L2-broadcast services need traffic to bypass fwbr."
+    },
     "disk_ssd": {
       "type": "boolean",
       "description": "Enable SSD emulation (ssd=1) for better performance on SSD/NVMe storage"

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -6,7 +6,10 @@ package provider
 
 // Data is the provider custom machine config.
 type Data struct {
-	Balloon         *bool            `yaml:"balloon,omitempty"`
+	Balloon *bool `yaml:"balloon,omitempty"`
+	// NetworkFirewall enables the per-VM firewall (fwbr) on the primary NIC.
+	// Defaults to true. Set false when L2-broadcast services need traffic to bypass fwbr.
+	NetworkFirewall *bool            `yaml:"network_firewall,omitempty"`
 	Node            string           `yaml:"node,omitempty"`
 	StorageSelector string           `yaml:"storage_selector,omitempty"`
 	NetworkBridge   string           `yaml:"network_bridge"`

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -297,12 +297,21 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				data.NetworkBridge = "vmbr0"
 			}
 
+			// network_firewall defaults to true for backward-compatibility
+			// with the previous hardcoded behavior. Set false in providerdata
+			// to opt out when L2-broadcast services need traffic to bypass
+			// the per-VM fwbr bridge.
+			primaryFirewall := 1
+			if data.NetworkFirewall != nil && !*data.NetworkFirewall {
+				primaryFirewall = 0
+			}
+
 			// Parse out the network config
 			var networkString string
 			if data.Vlan == 0 {
-				networkString = fmt.Sprintf("virtio,bridge=%s,firewall=1", data.NetworkBridge)
+				networkString = fmt.Sprintf("virtio,bridge=%s,firewall=%d", data.NetworkBridge, primaryFirewall)
 			} else {
-				networkString = fmt.Sprintf("virtio,bridge=%s,firewall=1,tag=%d", data.NetworkBridge, data.Vlan)
+				networkString = fmt.Sprintf("virtio,bridge=%s,firewall=%d,tag=%d", data.NetworkBridge, primaryFirewall, data.Vlan)
 			}
 
 			// Build primary disk options


### PR DESCRIPTION
## Problem

The primary NIC's qemu config is hardcoded with `firewall=1`. On clusters where MetalLB (or any L2 advertisement mechanism) requires ARP responses to leave the per-VM `fwbr` bridge, this flag breaks LoadBalancer Service reachability from outside the host. ARP for the service IP simply doesn't propagate.

`AdditionalNIC` already exposes a per-NIC `Firewall` flag (`internal/pkg/provider/data.go`), so per-NIC firewall control is already a precedent in this provider — it's just missing on the primary NIC.

## Change

- New optional field on the `Data` struct: `NetworkFirewall *bool` (yaml: `network_firewall`)
- `*bool` semantics: `nil` (unset) → keep current behavior (`firewall=1`). Backward compatible.
- `network_firewall: false` in providerdata → `firewall=0` in the net0 line.
- `network_firewall: true` is explicit and equivalent to the default.

## Sample providerdata

```yaml
cores: 2
sockets: 1
memory: 6144
disk_size: 50
network_bridge: vmbr0
network_firewall: false   # NEW — opt out of fwbr for MetalLB / L2 advertisement
storage_selector: name == "local-lvm"
node: pve
```

## Tests

`go build ./...` and `go vet ./...` pass.

I've verified the resulting `qm config net0` line shows `firewall=0` when the flag is set, and `firewall=1` (unchanged) when omitted.

## Related issues

Same root cause as the L2-advertisement issues other users have reported when MetalLB fails to ARP-respond for cluster LB IPs.