### PR TITLE
fix: stop clumping one node into OOM on non-exclusive pmx clusters

### DIFF
--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -4,6 +4,8 @@
 
 package provider
 
+import "time"
+
 type NodeStatus = nodeStatus
 
 func PickNode(nodes []NodeStatus) NodeStatus {
@@ -16,4 +18,18 @@ func BuildTagsOption(userTags []string, machineRequestSet string) (string, bool)
 
 func PoolCreateDecision(exists bool, poolID, machineRequestSet string) (bool, error) {
 	return poolCreateDecision(exists, poolID, machineRequestSet)
+}
+
+type Scheduler = scheduler
+
+func NewScheduler() *Scheduler {
+	return newScheduler()
+}
+
+func NewSchedulerWithClock(now func() time.Time, ttl time.Duration) *Scheduler {
+	return newSchedulerWithClock(now, ttl)
+}
+
+func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, materialized map[string]struct{}) NodeStatus {
+	return s.pick(nodes, set, requestID, materialized)
 }

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -33,3 +33,7 @@ func NewSchedulerWithClock(now func() time.Time, ttl time.Duration) *Scheduler {
 func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, materialized map[string]struct{}) NodeStatus {
 	return s.pick(nodes, set, requestID, materialized)
 }
+
+func (s *scheduler) Release(requestID string) {
+	s.release(requestID)
+}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -637,6 +637,10 @@ hostname: %s`,
 
 // Deprovision implements infra.Provisioner.
 func (p *Provisioner) Deprovision(ctx context.Context, logger *zap.Logger, machine *resources.Machine, machineRequest *infra.MachineRequest) error {
+	// release up front: a request torn down before its VM materializes returns
+	// at the Vmid == 0 check below.
+	p.scheduler.release(machineRequest.Metadata().ID())
+
 	if machine.TypedSpec().Value.Vmid == 0 {
 		return nil
 	}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -38,6 +38,7 @@ const (
 // Provisioner implements Talos emulator infra provider.
 type Provisioner struct {
 	proxmoxClient         *proxmox.Client
+	scheduler             *scheduler
 	pendingISODownloads   map[string]string
 	pendingISODownloadsMu sync.Mutex
 	poolMu                sync.Mutex
@@ -47,6 +48,7 @@ type Provisioner struct {
 func NewProvisioner(proxmoxClient *proxmox.Client) *Provisioner {
 	return &Provisioner{
 		proxmoxClient:       proxmoxClient,
+		scheduler:           newScheduler(),
 		pendingISODownloads: make(map[string]string),
 	}
 }
@@ -57,6 +59,10 @@ func NewProvisioner(proxmoxClient *proxmox.Client) *Provisioner {
 func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 	return []provision.Step[*resources.Machine]{
 		provision.NewStep("pickNode", func(ctx context.Context, logger *zap.Logger, pctx provision.Context[*resources.Machine]) error {
+			if pctx.State.TypedSpec().Value.Node != "" {
+				return nil
+			}
+
 			var data Data
 
 			if err := pctx.UnmarshalProviderData(&data); err != nil {
@@ -91,7 +97,10 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return fmt.Errorf("specified node %q not found in cluster", data.Node)
 			}
 
+			machineRequestSet, inSet := pctx.GetMachineRequestSetID()
+
 			nodeInfoList := make([]nodeStatus, 0, len(nodes))
+			materialized := map[string]struct{}{}
 
 			for _, node := range nodes {
 				// Skip nodes that are not online to avoid Proxmox API errors
@@ -106,7 +115,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				ns.Name = node.Node
 				ns.MemoryFree = float64(node.MaxMem-node.Mem) / float64(node.MaxMem)
 
-				if machineRequestSet, ok := pctx.GetMachineRequestSetID(); ok {
+				if inSet {
 					n, err := p.proxmoxClient.Node(ctx, node.Node)
 					if err != nil {
 						return fmt.Errorf("failed to get node %q, %w", node.Node, err)
@@ -114,12 +123,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 					vms, err := n.VirtualMachines(ctx)
 					if err != nil {
-						return fmt.Errorf("failed to get vms for now %q, %w", node.Node, err)
+						return fmt.Errorf("failed to get vms for node %q, %w", node.Node, err)
 					}
 
 					for _, vm := range vms {
 						if vm.HasTag(machineRequestTagPrefix + machineRequestSet) {
-							ns.SameMachineRequestSetVMs += 1
+							ns.SameMachineRequestSetVMs++
+							materialized[vm.Name] = struct{}{}
 						}
 					}
 				}
@@ -131,7 +141,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return fmt.Errorf("no online nodes available for provisioning")
 			}
 
-			pickedNode := pickNode(nodeInfoList)
+			var pickedNode nodeStatus
+
+			if inSet {
+				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), materialized)
+			} else {
+				pickedNode = pickNode(nodeInfoList)
+			}
 
 			pctx.State.TypedSpec().Value.Node = pickedNode.Name
 

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -6,6 +6,7 @@ package provider_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -171,4 +172,60 @@ func TestBuildTagsOption(t *testing.T) {
 			require.Equal(t, tt.expectedValue, value)
 		})
 	}
+}
+
+func TestSchedulerSpreadsInFlightPlacements(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 0.9},
+			{Name: "node-b", MemoryFree: 0.8},
+			{Name: "node-c", MemoryFree: 0.7},
+		}
+	}
+
+	var picked []string
+
+	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
+		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, nil).Name)
+	}
+
+	require.ElementsMatch(t, []string{"node-a", "node-b", "node-c"}, picked)
+}
+
+func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
+	s := provider.NewScheduler()
+
+	twoNodes := func(proxmoxOnA int) []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 1.0, SameMachineRequestSetVMs: proxmoxOnA},
+			{Name: "node-b", MemoryFree: 0.9},
+		}
+	}
+
+	require.Equal(t, "node-a", s.Pick(twoNodes(0), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, "node-b", s.Pick(twoNodes(0), talosWorkers, "worker-2", nil).Name)
+
+	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", map[string]struct{}{"worker-1": {}})
+
+	require.Equal(t, "node-a", picked.Name)
+}
+
+func TestSchedulerExpiresStaleReservations(t *testing.T) {
+	now := time.Unix(0, 0).UTC()
+	s := provider.NewSchedulerWithClock(func() time.Time { return now }, time.Minute)
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 1.0},
+			{Name: "node-b", MemoryFree: 0.9},
+		}
+	}
+
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
+
+	now = now.Add(2 * time.Minute)
+
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
 }

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -234,3 +234,21 @@ func TestSchedulerExpiresStaleReservations(t *testing.T) {
 
 	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
 }
+
+func TestSchedulerReleaseFreesReservedNode(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: nodeAName, MemoryFree: 1.0},
+			{Name: nodeBName, MemoryFree: 0.9},
+		}
+	}
+
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
+
+	s.Release("worker-2")
+
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-3", nil).Name)
+}

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -13,7 +13,12 @@ import (
 	"github.com/siderolabs/omni-infra-provider-proxmox/internal/pkg/provider"
 )
 
-const talosWorkers = "talos-workers"
+const (
+	talosWorkers = "talos-workers"
+
+	nodeAName = "node-a"
+	nodeBName = "node-b"
+)
 
 func TestPickNode(t *testing.T) {
 	const (
@@ -179,19 +184,19 @@ func TestSchedulerSpreadsInFlightPlacements(t *testing.T) {
 
 	nodes := func() []provider.NodeStatus {
 		return []provider.NodeStatus{
-			{Name: "node-a", MemoryFree: 0.9},
-			{Name: "node-b", MemoryFree: 0.8},
+			{Name: nodeAName, MemoryFree: 0.9},
+			{Name: nodeBName, MemoryFree: 0.8},
 			{Name: "node-c", MemoryFree: 0.7},
 		}
 	}
 
-	var picked []string
+	picked := make([]string, 0, 3)
 
 	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
 		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, nil).Name)
 	}
 
-	require.ElementsMatch(t, []string{"node-a", "node-b", "node-c"}, picked)
+	require.ElementsMatch(t, []string{nodeAName, nodeBName, "node-c"}, picked)
 }
 
 func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
@@ -199,17 +204,17 @@ func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
 
 	twoNodes := func(proxmoxOnA int) []provider.NodeStatus {
 		return []provider.NodeStatus{
-			{Name: "node-a", MemoryFree: 1.0, SameMachineRequestSetVMs: proxmoxOnA},
-			{Name: "node-b", MemoryFree: 0.9},
+			{Name: nodeAName, MemoryFree: 1.0, SameMachineRequestSetVMs: proxmoxOnA},
+			{Name: nodeBName, MemoryFree: 0.9},
 		}
 	}
 
-	require.Equal(t, "node-a", s.Pick(twoNodes(0), talosWorkers, "worker-1", nil).Name)
-	require.Equal(t, "node-b", s.Pick(twoNodes(0), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(twoNodes(0), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(twoNodes(0), talosWorkers, "worker-2", nil).Name)
 
 	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", map[string]struct{}{"worker-1": {}})
 
-	require.Equal(t, "node-a", picked.Name)
+	require.Equal(t, nodeAName, picked.Name)
 }
 
 func TestSchedulerExpiresStaleReservations(t *testing.T) {
@@ -218,14 +223,14 @@ func TestSchedulerExpiresStaleReservations(t *testing.T) {
 
 	nodes := func() []provider.NodeStatus {
 		return []provider.NodeStatus{
-			{Name: "node-a", MemoryFree: 1.0},
-			{Name: "node-b", MemoryFree: 0.9},
+			{Name: nodeAName, MemoryFree: 1.0},
+			{Name: nodeBName, MemoryFree: 0.9},
 		}
 	}
 
-	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
 
 	now = now.Add(2 * time.Minute)
 
-	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
 }

--- a/internal/pkg/provider/scheduler.go
+++ b/internal/pkg/provider/scheduler.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"sync"
+	"time"
+)
+
+// reservationTTL backstops placements whose VM never becomes visible in Proxmox.
+const reservationTTL = time.Hour
+
+type reservation struct {
+	at   time.Time
+	node string
+	set  string
+}
+
+// scheduler accounts for in-flight placements so concurrent VMs in a machine
+// request set spread across nodes instead of clumping onto one.
+type scheduler struct {
+	now          func() time.Time
+	reservations map[string]reservation
+	ttl          time.Duration
+	mu           sync.Mutex
+}
+
+func newScheduler() *scheduler {
+	return newSchedulerWithClock(time.Now, reservationTTL)
+}
+
+func newSchedulerWithClock(now func() time.Time, ttl time.Duration) *scheduler {
+	return &scheduler{
+		now:          now,
+		reservations: map[string]reservation{},
+		ttl:          ttl,
+	}
+}
+
+func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized map[string]struct{}) nodeStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+
+	for id, r := range s.reservations {
+		if _, done := materialized[id]; done || now.Sub(r.at) > s.ttl {
+			delete(s.reservations, id)
+		}
+	}
+
+	inFlight := map[string]int{}
+
+	for id, r := range s.reservations {
+		if id == requestID || r.set != set {
+			continue
+		}
+
+		inFlight[r.node]++
+	}
+
+	for i := range nodes {
+		nodes[i].SameMachineRequestSetVMs += inFlight[nodes[i].Name]
+	}
+
+	picked := pickNode(nodes)
+
+	s.reservations[requestID] = reservation{node: picked.Name, set: set, at: now}
+
+	return picked
+}

--- a/internal/pkg/provider/scheduler.go
+++ b/internal/pkg/provider/scheduler.go
@@ -71,3 +71,12 @@ func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized
 
 	return picked
 }
+
+// release drops a request's reservation when its VM is deprovisioned, so a node
+// removed before the VM materializes doesn't strand ledger data until the TTL.
+func (s *scheduler) release(requestID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.reservations, requestID)
+}


### PR DESCRIPTION
problem: pickNode scores nodes by VMs already tagged for the request set, then
free memory. Tag only gets set a few steps later (after the ISO upload), so a
batch from one set all read count 0 → free-mem tiebreak → every replica on one
node. Share that pmx host with other workloads and it OOMs. Found it on a 3-node
control plane, all 3 cp on one host.

fix: in-flight ledger of picks not yet visible in pmx, counted alongside the
tagged ones so concurrent picks in a set see each other. Entries clear when the
vm appears, 1h ttl backstop. pickNode idempotent on retry. No config change,
default stays spread.

conform gpg check will be red, not in the siderolabs org. signed + DCO regardless.

(it took way too long for this insomniac to understand what the process to open a proper pr per your standards)