### PR TITLE
feat: add placement strategies for node selection

### DIFF
--- a/cmd/omni-infra-provider-proxmox/data/schema.json
+++ b/cmd/omni-infra-provider-proxmox/data/schema.json
@@ -19,6 +19,16 @@
       "type": "string",
       "description": "Run the VM on a specific Proxmox node"
     },
+    "placement_strategy": {
+      "type": "string",
+      "enum": [
+        "spread",
+        "fewer-vms",
+        "round-robin",
+        "binpack"
+      ],
+      "description": "Node selection strategy for auto-provisioned VMs, ignored when 'node' is set. 'spread' (default) balances by free memory, 'fewer-vms' prefers nodes running the fewest VMs, 'round-robin' cycles nodes within a machine request set, 'binpack' packs onto the most-loaded node that still fits."
+    },
     "memory": {
       "type": "integer",
       "minimum": 2048,

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -13,29 +13,32 @@ type Data struct {
 	HA *ha.Config `yaml:"ha,omitempty"`
 	// NetworkFirewall enables the per-VM firewall (fwbr) on the primary NIC.
 	// Defaults to true. Set false when L2-broadcast services need traffic to bypass fwbr.
-	NetworkFirewall *bool            `yaml:"network_firewall,omitempty"`
-	Node            string           `yaml:"node,omitempty"`
-	StorageSelector string           `yaml:"storage_selector,omitempty"`
-	NetworkBridge   string           `yaml:"network_bridge"`
-	Hugepages       string           `yaml:"hugepages,omitempty"`
-	MachineType     string           `yaml:"machine_type,omitempty"`
-	CPUType         string           `yaml:"cpu_type,omitempty"`
-	DiskAIO         string           `yaml:"disk_aio,omitempty"`
-	DiskCache       string           `yaml:"disk_cache,omitempty"`
-	Pool            string           `yaml:"pool,omitempty"`
-	AdditionalDisks []AdditionalDisk `yaml:"additional_disks,omitempty"`
-	AdditionalNICs  []AdditionalNIC  `yaml:"additional_nics,omitempty"`
-	PCIDevices      []PCIDevice      `yaml:"pci_devices,omitempty"`
-	Tags            []string         `yaml:"tags,omitempty"`
-	Vlan            uint64           `yaml:"vlan"`
-	Memory          uint64           `yaml:"memory"`
-	Sockets         int              `yaml:"sockets"`
-	DiskSize        int              `yaml:"disk_size"`
-	Cores           int              `yaml:"cores"`
-	DiskIOThread    bool             `yaml:"disk_iothread,omitempty"`
-	NUMA            bool             `yaml:"numa,omitempty"`
-	DiskDiscard     bool             `yaml:"disk_discard,omitempty"`
-	DiskSSD         bool             `yaml:"disk_ssd,omitempty"`
+	NetworkFirewall *bool  `yaml:"network_firewall,omitempty"`
+	Node            string `yaml:"node,omitempty"`
+	StorageSelector string `yaml:"storage_selector,omitempty"`
+	NetworkBridge   string `yaml:"network_bridge"`
+	Hugepages       string `yaml:"hugepages,omitempty"`
+	MachineType     string `yaml:"machine_type,omitempty"`
+	CPUType         string `yaml:"cpu_type,omitempty"`
+	DiskAIO         string `yaml:"disk_aio,omitempty"`
+	DiskCache       string `yaml:"disk_cache,omitempty"`
+	Pool            string `yaml:"pool,omitempty"`
+	// PlacementStrategy selects how a node is chosen for an auto-provisioned VM:
+	// spread (default), fewer-vms, round-robin or binpack.
+	PlacementStrategy string           `yaml:"placement_strategy,omitempty"`
+	AdditionalDisks   []AdditionalDisk `yaml:"additional_disks,omitempty"`
+	AdditionalNICs    []AdditionalNIC  `yaml:"additional_nics,omitempty"`
+	PCIDevices        []PCIDevice      `yaml:"pci_devices,omitempty"`
+	Tags              []string         `yaml:"tags,omitempty"`
+	Vlan              uint64           `yaml:"vlan"`
+	Memory            uint64           `yaml:"memory"`
+	Sockets           int              `yaml:"sockets"`
+	DiskSize          int              `yaml:"disk_size"`
+	Cores             int              `yaml:"cores"`
+	DiskIOThread      bool             `yaml:"disk_iothread,omitempty"`
+	NUMA              bool             `yaml:"numa,omitempty"`
+	DiskDiscard       bool             `yaml:"disk_discard,omitempty"`
+	DiskSSD           bool             `yaml:"disk_ssd,omitempty"`
 }
 
 // AdditionalDisk represents an additional disk configuration.

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -31,15 +31,15 @@ func NewSchedulerWithClock(now func() time.Time, ttl time.Duration) *Scheduler {
 }
 
 func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, memory uint64, strategy string, materialized map[string]struct{}) NodeStatus {
-	strat, _ := parseStrategy(strategy)
+	parsed, _ := parseStrategy(strategy) //nolint:errcheck
 
-	return s.pick(nodes, set, requestID, memory, strat, materialized)
+	return s.pick(nodes, set, requestID, memory, parsed, materialized)
 }
 
 func ParseStrategy(s string) (string, error) {
-	strat, err := parseStrategy(s)
+	parsed, err := parseStrategy(s)
 
-	return string(strat), err
+	return string(parsed), err
 }
 
 func (s *scheduler) Release(requestID string) {

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -30,8 +30,16 @@ func NewSchedulerWithClock(now func() time.Time, ttl time.Duration) *Scheduler {
 	return newSchedulerWithClock(now, ttl)
 }
 
-func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, materialized map[string]struct{}) NodeStatus {
-	return s.pick(nodes, set, requestID, materialized)
+func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, memory uint64, strategy string, materialized map[string]struct{}) NodeStatus {
+	strat, _ := parseStrategy(strategy)
+
+	return s.pick(nodes, set, requestID, memory, strat, materialized)
+}
+
+func ParseStrategy(s string) (string, error) {
+	strat, err := parseStrategy(s)
+
+	return string(strat), err
 }
 
 func (s *scheduler) Release(requestID string) {

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -72,11 +72,6 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return err
 			}
 
-			strat, err := parseStrategy(data.PlacementStrategy)
-			if err != nil {
-				return err
-			}
-
 			nodes, err := p.proxmoxClient.Nodes(ctx)
 			if err != nil {
 				return err
@@ -105,6 +100,11 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return fmt.Errorf("specified node %q not found in cluster", data.Node)
 			}
 
+			strat, err := parseStrategy(data.PlacementStrategy)
+			if err != nil {
+				return err
+			}
+
 			machineRequestSet, inSet := pctx.GetMachineRequestSetID()
 
 			nodeInfoList := make([]nodeStatus, 0, len(nodes))
@@ -121,13 +121,15 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				var ns nodeStatus
 
 				ns.Name = node.Node
-				ns.MemoryFree = float64(node.MaxMem-node.Mem) / float64(node.MaxMem)
 
-				// FreeMem is unsigned; guard the subtraction in case Proxmox ever
-				// reports used memory above the node total.
-				// (hopefully that stray universal electron and caffeinated devs won't ever cause this)
+				// MaxMem/Mem are unsigned; guard the subtraction in case Proxmox ever
+				// reports used memory above the node total, and avoid div-by-zero.
 				if node.MaxMem > node.Mem {
 					ns.FreeMem = node.MaxMem - node.Mem
+				}
+
+				if node.MaxMem > 0 {
+					ns.MemoryFree = float64(ns.FreeMem) / float64(node.MaxMem)
 				}
 
 				if shouldCountSetVMs(data, inSet) {

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -72,6 +72,11 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return err
 			}
 
+			strat, err := parseStrategy(data.PlacementStrategy)
+			if err != nil {
+				return err
+			}
+
 			nodes, err := p.proxmoxClient.Nodes(ctx)
 			if err != nil {
 				return err
@@ -118,6 +123,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				ns.Name = node.Node
 				ns.MemoryFree = float64(node.MaxMem-node.Mem) / float64(node.MaxMem)
 
+				// FreeMem is unsigned; guard the subtraction in case Proxmox ever
+				// reports used memory above the node total.
+				// (hopefully that stray universal electron and caffeinated devs won't ever cause this)
+				if node.MaxMem > node.Mem {
+					ns.FreeMem = node.MaxMem - node.Mem
+				}
+
 				if shouldCountSetVMs(data, inSet) {
 					n, err := p.proxmoxClient.Node(ctx, node.Node)
 					if err != nil {
@@ -128,6 +140,8 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					if err != nil {
 						return fmt.Errorf("failed to get vms for node %q, %w", node.Node, err)
 					}
+
+					ns.TotalVMs = len(vms)
 
 					for _, vm := range vms {
 						if vm.HasTag(machineRequestTagPrefix + machineRequestSet) {
@@ -147,7 +161,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			var pickedNode nodeStatus
 
 			if inSet {
-				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), materialized)
+				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), data.Memory*1024*1024, strat, materialized)
 			} else {
 				pickedNode = pickNode(nodeInfoList)
 			}
@@ -924,7 +938,9 @@ func (p *Provisioner) waitForTaskToFinish(ctx context.Context, t *proxmox.Task) 
 type nodeStatus struct {
 	Name                     string
 	MemoryFree               float64
+	FreeMem                  uint64
 	SameMachineRequestSetVMs int
+	TotalVMs                 int
 }
 
 // shouldCountSetVMs disables the client-side set spread under HA, where Proxmox owns placement.

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -100,7 +100,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return fmt.Errorf("specified node %q not found in cluster", data.Node)
 			}
 
-			strat, err := parseStrategy(data.PlacementStrategy)
+			strategy, err := parseStrategy(data.PlacementStrategy)
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			var pickedNode nodeStatus
 
 			if inSet {
-				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), data.Memory*1024*1024, strat, materialized)
+				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), data.Memory*1024*1024, strategy, materialized)
 			} else {
 				pickedNode = pickNode(nodeInfoList)
 			}

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -19,6 +19,11 @@ const (
 
 	nodeAName = "node-a"
 	nodeBName = "node-b"
+	nodeCName = "node-c"
+
+	worker1 = "worker-1"
+	worker2 = "worker-2"
+	worker3 = "worker-3"
 )
 
 func TestPickNode(t *testing.T) {
@@ -207,17 +212,17 @@ func TestSchedulerSpreadsInFlightPlacements(t *testing.T) {
 		return []provider.NodeStatus{
 			{Name: nodeAName, MemoryFree: 0.9},
 			{Name: nodeBName, MemoryFree: 0.8},
-			{Name: "node-c", MemoryFree: 0.7},
+			{Name: nodeCName, MemoryFree: 0.7},
 		}
 	}
 
 	picked := make([]string, 0, 3)
 
-	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
+	for _, requestID := range []string{worker1, worker2, worker3} {
 		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, 0, "spread", nil).Name)
 	}
 
-	require.ElementsMatch(t, []string{nodeAName, nodeBName, "node-c"}, picked)
+	require.ElementsMatch(t, []string{nodeAName, nodeBName, nodeCName}, picked)
 }
 
 func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
@@ -230,10 +235,10 @@ func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeAName, s.Pick(twoNodes(0), talosWorkers, "worker-1", 0, "spread", nil).Name)
-	require.Equal(t, nodeBName, s.Pick(twoNodes(0), talosWorkers, "worker-2", 0, "spread", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(twoNodes(0), talosWorkers, worker1, 0, "spread", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(twoNodes(0), talosWorkers, worker2, 0, "spread", nil).Name)
 
-	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", 0, "spread", map[string]struct{}{"worker-1": {}})
+	picked := s.Pick(twoNodes(1), talosWorkers, worker3, 0, "spread", map[string]struct{}{worker1: {}})
 
 	require.Equal(t, nodeAName, picked.Name)
 }
@@ -249,11 +254,11 @@ func TestSchedulerExpiresStaleReservations(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", 0, "spread", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, worker1, 0, "spread", nil).Name)
 
 	now = now.Add(2 * time.Minute)
 
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", 0, "spread", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, worker2, 0, "spread", nil).Name)
 }
 
 func TestSchedulerReleaseFreesReservedNode(t *testing.T) {
@@ -266,12 +271,12 @@ func TestSchedulerReleaseFreesReservedNode(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", 0, "spread", nil).Name)
-	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-2", 0, "spread", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, worker1, 0, "spread", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, worker2, 0, "spread", nil).Name)
 
-	s.Release("worker-2")
+	s.Release(worker2)
 
-	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-3", 0, "spread", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, worker3, 0, "spread", nil).Name)
 }
 
 func TestSchedulerRoundRobinIgnoresMemory(t *testing.T) {
@@ -283,17 +288,17 @@ func TestSchedulerRoundRobinIgnoresMemory(t *testing.T) {
 		return []provider.NodeStatus{
 			{Name: nodeAName, MemoryFree: 0.1},
 			{Name: nodeBName, MemoryFree: 0.5},
-			{Name: "node-c", MemoryFree: 0.9},
+			{Name: nodeCName, MemoryFree: 0.9},
 		}
 	}
 
-	var picked []string
+	picked := make([]string, 0, 3)
 
-	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
+	for _, requestID := range []string{worker1, worker2, worker3} {
 		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, 0, "round-robin", nil).Name)
 	}
 
-	require.Equal(t, []string{nodeAName, nodeBName, "node-c"}, picked)
+	require.Equal(t, []string{nodeAName, nodeBName, nodeCName}, picked)
 }
 
 func TestSchedulerFewerVMsBalancesTotalLoad(t *testing.T) {
@@ -304,7 +309,7 @@ func TestSchedulerFewerVMsBalancesTotalLoad(t *testing.T) {
 		{Name: nodeBName, TotalVMs: 1, SameMachineRequestSetVMs: 3, MemoryFree: 0.5},
 	}
 
-	require.Equal(t, nodeBName, s.Pick(nodes, talosWorkers, "worker-1", 0, "fewer-vms", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes, talosWorkers, worker1, 0, "fewer-vms", nil).Name)
 }
 
 func TestSchedulerBinpackConsolidatesOntoNodesThatFit(t *testing.T) {
@@ -317,8 +322,8 @@ func TestSchedulerBinpackConsolidatesOntoNodesThatFit(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-1", 40, "binpack", nil).Name)
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", 60, "binpack", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, worker1, 40, "binpack", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, worker2, 60, "binpack", nil).Name)
 }
 
 func TestParseStrategy(t *testing.T) {

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -214,7 +214,7 @@ func TestSchedulerSpreadsInFlightPlacements(t *testing.T) {
 	picked := make([]string, 0, 3)
 
 	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
-		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, nil).Name)
+		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, 0, "spread", nil).Name)
 	}
 
 	require.ElementsMatch(t, []string{nodeAName, nodeBName, "node-c"}, picked)
@@ -230,10 +230,10 @@ func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeAName, s.Pick(twoNodes(0), talosWorkers, "worker-1", nil).Name)
-	require.Equal(t, nodeBName, s.Pick(twoNodes(0), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(twoNodes(0), talosWorkers, "worker-1", 0, "spread", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(twoNodes(0), talosWorkers, "worker-2", 0, "spread", nil).Name)
 
-	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", map[string]struct{}{"worker-1": {}})
+	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", 0, "spread", map[string]struct{}{"worker-1": {}})
 
 	require.Equal(t, nodeAName, picked.Name)
 }
@@ -249,11 +249,11 @@ func TestSchedulerExpiresStaleReservations(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", 0, "spread", nil).Name)
 
 	now = now.Add(2 * time.Minute)
 
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", 0, "spread", nil).Name)
 }
 
 func TestSchedulerReleaseFreesReservedNode(t *testing.T) {
@@ -266,10 +266,67 @@ func TestSchedulerReleaseFreesReservedNode(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
-	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-1", 0, "spread", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-2", 0, "spread", nil).Name)
 
 	s.Release("worker-2")
 
-	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-3", nil).Name)
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-3", 0, "spread", nil).Name)
+}
+
+func TestSchedulerRoundRobinIgnoresMemory(t *testing.T) {
+	s := provider.NewScheduler()
+
+	// Memory order (c>b>a) is the inverse of name order, so a name-ordered
+	// result proves round-robin ignores free memory.
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: nodeAName, MemoryFree: 0.1},
+			{Name: nodeBName, MemoryFree: 0.5},
+			{Name: "node-c", MemoryFree: 0.9},
+		}
+	}
+
+	var picked []string
+
+	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
+		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, 0, "round-robin", nil).Name)
+	}
+
+	require.Equal(t, []string{nodeAName, nodeBName, "node-c"}, picked)
+}
+
+func TestSchedulerFewerVMsBalancesTotalLoad(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := []provider.NodeStatus{
+		{Name: nodeAName, TotalVMs: 9, SameMachineRequestSetVMs: 0, MemoryFree: 0.5},
+		{Name: nodeBName, TotalVMs: 1, SameMachineRequestSetVMs: 3, MemoryFree: 0.5},
+	}
+
+	require.Equal(t, nodeBName, s.Pick(nodes, talosWorkers, "worker-1", 0, "fewer-vms", nil).Name)
+}
+
+func TestSchedulerBinpackConsolidatesOntoNodesThatFit(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: nodeAName, FreeMem: 100},
+			{Name: nodeBName, FreeMem: 50},
+		}
+	}
+
+	require.Equal(t, nodeBName, s.Pick(nodes(), talosWorkers, "worker-1", 40, "binpack", nil).Name)
+	require.Equal(t, nodeAName, s.Pick(nodes(), talosWorkers, "worker-2", 60, "binpack", nil).Name)
+}
+
+func TestParseStrategy(t *testing.T) {
+	for _, valid := range []string{"", "spread", "fewer-vms", "round-robin", "binpack"} {
+		_, err := provider.ParseStrategy(valid)
+		require.NoError(t, err)
+	}
+
+	_, err := provider.ParseStrategy("nonsense")
+	require.Error(t, err)
 }

--- a/internal/pkg/provider/scheduler.go
+++ b/internal/pkg/provider/scheduler.go
@@ -5,21 +5,44 @@
 package provider
 
 import (
+	"cmp"
+	"fmt"
+	"slices"
 	"sync"
 	"time"
 )
 
-// reservationTTL backstops placements whose VM never becomes visible in Proxmox.
 const reservationTTL = time.Hour
 
+type placementStrategy string
+
+const (
+	strategySpread     placementStrategy = "spread"
+	strategyFewerVMs   placementStrategy = "fewer-vms"
+	strategyRoundRobin placementStrategy = "round-robin"
+	strategyBinpack    placementStrategy = "binpack"
+)
+
+func parseStrategy(s string) (placementStrategy, error) {
+	switch placementStrategy(s) {
+	case "", strategySpread:
+		return strategySpread, nil
+	case strategyFewerVMs, strategyRoundRobin, strategyBinpack:
+		return placementStrategy(s), nil
+	default:
+		return "", fmt.Errorf("unknown placement strategy %q", s)
+	}
+}
+
 type reservation struct {
-	at   time.Time
-	node string
-	set  string
+	at     time.Time
+	node   string
+	set    string
+	memory uint64
 }
 
 // scheduler accounts for in-flight placements so concurrent VMs in a machine
-// request set spread across nodes instead of clumping onto one.
+// request set are distributed by the chosen strategy instead of clumping.
 type scheduler struct {
 	now          func() time.Time
 	reservations map[string]reservation
@@ -39,7 +62,7 @@ func newSchedulerWithClock(now func() time.Time, ttl time.Duration) *scheduler {
 	}
 }
 
-func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized map[string]struct{}) nodeStatus {
+func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, memory uint64, strat placementStrategy, materialized map[string]struct{}) nodeStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -51,23 +74,24 @@ func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized
 		}
 	}
 
-	inFlight := map[string]int{}
+	byName := make(map[string]*nodeStatus, len(nodes))
+	for i := range nodes {
+		byName[nodes[i].Name] = &nodes[i]
+	}
 
 	for id, r := range s.reservations {
 		if id == requestID || r.set != set {
 			continue
 		}
 
-		inFlight[r.node]++
+		if ns, ok := byName[r.node]; ok {
+			applyReservation(strat, ns, r)
+		}
 	}
 
-	for i := range nodes {
-		nodes[i].SameMachineRequestSetVMs += inFlight[nodes[i].Name]
-	}
+	picked := selectNode(strat, nodes, memory)
 
-	picked := pickNode(nodes)
-
-	s.reservations[requestID] = reservation{node: picked.Name, set: set, at: now}
+	s.reservations[requestID] = reservation{node: picked.Name, set: set, memory: memory, at: now}
 
 	return picked
 }
@@ -79,4 +103,75 @@ func (s *scheduler) release(requestID string) {
 	defer s.mu.Unlock()
 
 	delete(s.reservations, requestID)
+}
+
+func applyReservation(strat placementStrategy, ns *nodeStatus, r reservation) {
+	switch strat {
+	case strategyFewerVMs:
+		ns.TotalVMs++
+	case strategyBinpack:
+		// FreeMem is unsigned; an over-reserved node ranks as full, not wrapped.
+		if ns.FreeMem >= r.memory {
+			ns.FreeMem -= r.memory
+		} else {
+			ns.FreeMem = 0
+		}
+	case strategySpread, strategyRoundRobin:
+		ns.SameMachineRequestSetVMs++
+	}
+}
+
+func selectNode(strat placementStrategy, nodes []nodeStatus, memory uint64) nodeStatus {
+	switch strat {
+	case strategyFewerVMs:
+		slices.SortFunc(nodes, func(a, b nodeStatus) int {
+			if c := cmp.Compare(a.TotalVMs, b.TotalVMs); c != 0 {
+				return c
+			}
+
+			return -cmp.Compare(a.MemoryFree, b.MemoryFree)
+		})
+
+		return nodes[0]
+	case strategyRoundRobin:
+		slices.SortFunc(nodes, func(a, b nodeStatus) int {
+			if c := cmp.Compare(a.SameMachineRequestSetVMs, b.SameMachineRequestSetVMs); c != 0 {
+				return c
+			}
+
+			return cmp.Compare(a.Name, b.Name)
+		})
+
+		return nodes[0]
+	case strategyBinpack:
+		return pickBinpack(nodes, memory)
+	case strategySpread:
+		return pickNode(nodes)
+	default:
+		return pickNode(nodes)
+	}
+}
+
+// Prefer the most-loaded node that still fits the requested memory, falling back
+// to the node with the most free memory when none fit.
+func pickBinpack(nodes []nodeStatus, memory uint64) nodeStatus {
+	slices.SortFunc(nodes, func(a, b nodeStatus) int {
+		aFits, bFits := a.FreeMem >= memory, b.FreeMem >= memory
+
+		if aFits != bFits {
+			if aFits {
+				return -1
+			}
+
+			return 1
+		}
+
+		if aFits {
+			return cmp.Compare(a.FreeMem, b.FreeMem)
+		}
+
+		return -cmp.Compare(a.FreeMem, b.FreeMem)
+	})
+
+	return nodes[0]
 }

--- a/internal/pkg/provider/scheduler.go
+++ b/internal/pkg/provider/scheduler.go
@@ -62,7 +62,7 @@ func newSchedulerWithClock(now func() time.Time, ttl time.Duration) *scheduler {
 	}
 }
 
-func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, memory uint64, strat placementStrategy, materialized map[string]struct{}) nodeStatus {
+func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, memory uint64, strategy placementStrategy, materialized map[string]struct{}) nodeStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -85,11 +85,11 @@ func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, memory uint6
 		}
 
 		if ns, ok := byName[r.node]; ok {
-			applyReservation(strat, ns, r)
+			applyReservation(strategy, ns, r)
 		}
 	}
 
-	picked := selectNode(strat, nodes, memory)
+	picked := selectNode(strategy, nodes, memory)
 
 	s.reservations[requestID] = reservation{node: picked.Name, set: set, memory: memory, at: now}
 
@@ -105,8 +105,8 @@ func (s *scheduler) release(requestID string) {
 	delete(s.reservations, requestID)
 }
 
-func applyReservation(strat placementStrategy, ns *nodeStatus, r reservation) {
-	switch strat {
+func applyReservation(strategy placementStrategy, ns *nodeStatus, r reservation) {
+	switch strategy {
 	case strategyFewerVMs:
 		ns.TotalVMs++
 	case strategyBinpack:
@@ -121,8 +121,8 @@ func applyReservation(strat placementStrategy, ns *nodeStatus, r reservation) {
 	}
 }
 
-func selectNode(strat placementStrategy, nodes []nodeStatus, memory uint64) nodeStatus {
-	switch strat {
+func selectNode(strategy placementStrategy, nodes []nodeStatus, memory uint64) nodeStatus {
+	switch strategy {
 	case strategyFewerVMs:
 		slices.SortFunc(nodes, func(a, b nodeStatus) int {
 			if c := cmp.Compare(a.TotalVMs, b.TotalVMs); c != 0 {


### PR DESCRIPTION
Stacked on #68 (the first commit is that fix, review after it merges).

feat: optional placement_strategy on the machine class:
  spread (default): fewest set VMs, then most free mem
  fewer-vms: fewest total VMs on the node
  round-robin: nodes by name, ignores mem
  binpack: fullest node that still fits, else most free

Same in-flight ledger as the fix, applied per strategy so spread/pack holds
before the vms show up.

how they differ, same start: nodes written node(free GB, total VMs), provision a
3x 8GB worker set onto node-a(40,8) node-b(50,2) node-c(20,5):

  spread       -> b, a, c   one per node, by free mem
  fewer-vms    -> b, b, b   node-b has fewest total VMs, fill it till it catches up
  round-robin  -> a, b, c   one per node, by name, ignores mem
  binpack      -> c, c, a   fill c until 8GB no longer fits, spill to a, leave b empty

identical nodes is the clean tell: 3 equal nodes, binpack stacks all 3 on one,
the others put one per node.

tests: in-flight spread, release-on-appear, ttl expiry, one per strategy.

conform gpg check will be red, not in the siderolabs org. signed + DCO regardless.