### PR TITLE
fix: improve checks for nodes removed bypassing the infra provider

### DIFF
--- a/internal/pkg/provider/ha/manager.go
+++ b/internal/pkg/provider/ha/manager.go
@@ -222,11 +222,22 @@ func (m *Manager) FindVMNode(ctx context.Context, vmid int32) (string, bool, err
 
 		node, err := m.px.Node(ctx, ns.Node)
 		if err != nil {
+			// A node removed or unreachable out-of-band must not abort the scan:
+			// the VM we are looking for may live on another node, and blocking
+			// here would wedge teardown of every HA machine. Skip it.
+			if isNodeUnreachable(err) {
+				continue
+			}
+
 			return "", false, fmt.Errorf("failed to get node %q: %w", ns.Node, err)
 		}
 
 		vms, err := node.VirtualMachines(ctx)
 		if err != nil {
+			if isNodeUnreachable(err) {
+				continue
+			}
+
 			return "", false, fmt.Errorf("failed to list vms on %q: %w", ns.Node, err)
 		}
 
@@ -238,6 +249,22 @@ func (m *Manager) FindVMNode(ctx context.Context, vmid int32) (string, bool, err
 	}
 
 	return "", false, nil
+}
+
+// isNodeUnreachable reports whether err is Proxmox failing to reach or resolve a
+// cluster node while proxying a per-node request (a node removed or offline
+// out-of-band). go-proxmox surfaces these only as the raw 500 reason phrase, so
+// the string is the only contract. Matching the same shapes classify handles
+// for HA resources, but for the node-proxy layer instead.
+func isNodeUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+
+	return strings.Contains(msg, "no such node") ||
+		(strings.Contains(msg, "hostname lookup") && strings.Contains(msg, "failed to get address info"))
 }
 
 // ensureNodeAffinity creates the node-affinity rule with sid as a member, or

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -701,7 +701,17 @@ func (p *Provisioner) Deprovision(ctx context.Context, logger *zap.Logger, machi
 
 	vm, err := p.getVM(ctx, node, machine.TypedSpec().Value.Vmid)
 	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
+		// The VM, or the node it was provisioned on, was removed out-of-band
+		// (directly in Proxmox). There is nothing left to tear down, so treat it
+		// as already deprovisioned and still clean up the pool.
+		if isAlreadyGoneErr(err) {
+			logger.Info("VM or its node no longer exists, treating as already deprovisioned",
+				zap.String("node", node), zap.Int32("vmid", machine.TypedSpec().Value.Vmid), zap.Error(err))
+
+			if pool := machine.TypedSpec().Value.Pool; pool != "" {
+				p.cleanupPool(ctx, logger, pool)
+			}
+
 			return nil
 		}
 
@@ -977,6 +987,35 @@ type nodeStatus struct {
 // shouldCountSetVMs disables the client-side set spread under HA, where Proxmox owns placement.
 func shouldCountSetVMs(data Data, hasSet bool) bool {
 	return hasSet && data.HA == nil
+}
+
+// isAlreadyGoneErr reports whether err means the VM, or the node it lived on,
+// no longer exists in Proxmox — e.g. it was deleted or the node was removed
+// out-of-band. On teardown such a machine has nothing left to clean up, so the
+// caller treats it as already deprovisioned instead of failing forever.
+//
+// go-proxmox flattens every 500 into errors.New(res.Status) with no type or
+// status code (proxmox.go handleResponse), so the reason phrase is the only
+// signal. The phrasings matched here are, respectively: a missing VM config
+// file, a node dropped from the cluster, and a node whose hostname no longer
+// resolves while Proxmox proxies the per-node request.
+func isAlreadyGoneErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+
+	switch {
+	case strings.Contains(msg, "does not exist"):
+		return true
+	case strings.Contains(msg, "no such node"):
+		return true
+	case strings.Contains(msg, "hostname lookup") && strings.Contains(msg, "failed to get address info"):
+		return true
+	default:
+		return false
+	}
 }
 
 func pickNode(nodeInfoList []nodeStatus) nodeStatus {


### PR DESCRIPTION
Do more string checks there with various possible errors returned.