### PR TITLE
feat: static IP/IPv6 networking in providerdata (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,86 @@ config:
 
 Replace `"local-lvm"` with the name of the storage you want to use for VM disks in your Proxmox cluster.
 
+### Static Networking (no DHCP)
+
+By default VMs use DHCP. To assign static IPv4/IPv6 addressing, add a `network:` block
+to the machine class `providerdata`. When omitted, DHCP behavior is unchanged.
+
+Two addressing modes are supported.
+
+**Explicit** — a single fixed IP. Use this for single-machine classes (e.g. a
+specific control-plane node); if a class provisions more than one machine they
+would all receive the same IP.
+
+```yaml
+providerdata: |
+  storage_selector: name == "local-lvm"
+  network_bridge: vmbr1
+  vlan: 2501
+  network:
+    subnet: 192.168.26.0/24
+    gateway: 192.168.26.1
+    nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+    ip_address: 192.168.26.31
+```
+
+**VMID-derived** — a unique IP per machine in a set, derived from the VM's VMID:
+
+```text
+ip = base_ip + (vmid - vmid_range.start)
+```
+
+The provider allocates each VM's VMID from `vmid_range` (lowest free first), so
+each machine gets a distinct, deterministic address.
+
+```yaml
+providerdata: |
+  storage_selector: name == "local-lvm"
+  network_bridge: vmbr1
+  vlan: 2501
+  vmid_range: 5300-5350
+  network:
+    subnet: 192.168.26.0/24
+    gateway: 192.168.26.1
+    nameservers:
+      - 8.8.8.8
+    base_ip: 192.168.26.10   # vmid 5300 -> .10, vmid 5304 -> .14
+```
+
+**IPv6** works the same way — use IPv6 values and the provider emits the correct
+config automatically. A class is single-family (IPv4 **or** IPv6), not
+dual-stack:
+
+```yaml
+providerdata: |
+  storage_selector: name == "local-lvm"
+  network_bridge: vmbr1
+  vmid_range: 5300-5350
+  network:
+    subnet: 2001:db8::/64
+    gateway: 2001:db8::1
+    nameservers:
+      - 2001:4860:4860::8888
+    base_ip: 2001:db8::10   # vmid 5304 -> 2001:db8::14
+```
+
+Notes:
+
+- `subnet` is required (CIDR, IPv4 or IPv6) and supplies the prefix; the family
+  is inferred from it and all other addresses in the block must match. Set
+  exactly one of `ip_address` or `base_ip`. `base_ip` requires `vmid_range`.
+- Configuration is validated up front: `base_ip` plus the full range width must
+  fit inside `subnet`, and IPs may not be the subnet network address (or the
+  IPv4 broadcast address) — a bad config fails the whole machine class
+  immediately.
+- The derived IP is stable per **VMID**, not per logical node. Deprovision +
+  reprovision reuses the lowest free VMID (fills holes first), so addresses are
+  recycled rather than permanently reserved.
+- Dedicate the `vmid_range` to this class. If Proxmox already holds a guest with
+  a VMID inside the range, allocation skips it, which shifts the derived offsets.
+
 ### High Availability
 
 Adding an `ha:` block to the machine class registers each provisioned VM as a Proxmox HA resource

--- a/cmd/omni-infra-provider-proxmox/data/schema.json
+++ b/cmd/omni-infra-provider-proxmox/data/schema.json
@@ -52,6 +52,45 @@
       "type": "boolean",
       "description": "Enable per-VM firewall (fwbr) on primary NIC. Defaults to true. Set false when L2-broadcast services need traffic to bypass fwbr."
     },
+    "vmid_range": {
+      "type": "string",
+      "pattern": "^[0-9]+-[0-9]+$",
+      "description": "Restrict VMID allocation to an inclusive \"start-end\" range (e.g. \"200-250\") instead of Proxmox NextID. Required when using network.base_ip for VMID-derived static IPs. Dedicate the range to this machine class."
+    },
+    "network": {
+      "type": "object",
+      "title": "Static Networking",
+      "description": "Static IPv4/IPv6 networking injected via cloud-init network-config. When omitted, the VM uses DHCP. Single-family per class (the address family is inferred from 'subnet'). Set exactly one of 'ip_address' (explicit) or 'base_ip' (VMID-derived, requires 'vmid_range').",
+      "properties": {
+        "subnet": {
+          "type": "string",
+          "description": "Subnet in CIDR notation, e.g. '192.168.26.0/24' or '2001:db8::/64'. Required; supplies the prefix length and the address family for the whole block."
+        },
+        "gateway": {
+          "type": "string",
+          "description": "Optional default gateway, e.g. '192.168.26.1'. Must be in the same family as 'subnet'."
+        },
+        "nameservers": {
+          "type": "array",
+          "description": "Optional DNS nameserver IP addresses.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "ip_address": {
+          "type": "string",
+          "description": "Explicit static IP for this VM, e.g. '192.168.26.31'. Use for single-machine classes (a shared class would assign every machine the same IP). Mutually exclusive with 'base_ip'."
+        },
+        "base_ip": {
+          "type": "string",
+          "description": "Base IP for VMID-derived addressing: each VM gets base_ip + (vmid - vmid_range.start), so a machine set gets unique deterministic IPs. Requires 'vmid_range'. Mutually exclusive with 'ip_address'."
+        }
+      },
+      "required": [
+        "subnet"
+      ]
+    },
     "disk_ssd": {
       "type": "boolean",
       "description": "Enable SSD emulation (ssd=1) for better performance on SSD/NVMe storage"

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -13,34 +13,40 @@ type Data struct {
 	HA *ha.Config `yaml:"ha,omitempty"`
 	// NetworkFirewall enables the per-VM firewall (fwbr) on the primary NIC.
 	// Defaults to true. Set false when L2-broadcast services need traffic to bypass fwbr.
-	NetworkFirewall *bool  `yaml:"network_firewall,omitempty"`
-	Node            string `yaml:"node,omitempty"`
-	StorageSelector string `yaml:"storage_selector,omitempty"`
-	NetworkBridge   string `yaml:"network_bridge"`
-	Hugepages       string `yaml:"hugepages,omitempty"`
-	MachineType     string `yaml:"machine_type,omitempty"`
-	Bios            string `yaml:"bios,omitempty"`
-	VGA             string `yaml:"vga,omitempty"`
-	CPUType         string `yaml:"cpu_type,omitempty"`
-	DiskAIO         string `yaml:"disk_aio,omitempty"`
-	DiskCache       string `yaml:"disk_cache,omitempty"`
-	Pool            string `yaml:"pool,omitempty"`
+	NetworkFirewall *bool `yaml:"network_firewall,omitempty"`
+	// Network, when non-nil, configures static IPv4/IPv6 networking via a cloud-init
+	// network-config v1 document. Nil keeps the default DHCP behavior.
+	Network         *NetworkConfig `yaml:"network,omitempty"`
+	Node            string         `yaml:"node,omitempty"`
+	StorageSelector string         `yaml:"storage_selector,omitempty"`
+	NetworkBridge   string         `yaml:"network_bridge"`
+	Hugepages       string         `yaml:"hugepages,omitempty"`
+	MachineType     string         `yaml:"machine_type,omitempty"`
+	Bios            string         `yaml:"bios,omitempty"`
+	VGA             string         `yaml:"vga,omitempty"`
+	CPUType         string         `yaml:"cpu_type,omitempty"`
+	DiskAIO         string         `yaml:"disk_aio,omitempty"`
+	DiskCache       string         `yaml:"disk_cache,omitempty"`
+	Pool            string         `yaml:"pool,omitempty"`
 	// PlacementStrategy selects how a node is chosen for an auto-provisioned VM:
 	// spread (default), fewer-vms, round-robin or binpack.
-	PlacementStrategy string           `yaml:"placement_strategy,omitempty"`
-	AdditionalDisks   []AdditionalDisk `yaml:"additional_disks,omitempty"`
-	AdditionalNICs    []AdditionalNIC  `yaml:"additional_nics,omitempty"`
-	PCIDevices        []PCIDevice      `yaml:"pci_devices,omitempty"`
-	Tags              []string         `yaml:"tags,omitempty"`
-	Vlan              uint64           `yaml:"vlan"`
-	Memory            uint64           `yaml:"memory"`
-	Sockets           int              `yaml:"sockets"`
-	DiskSize          int              `yaml:"disk_size"`
-	Cores             int              `yaml:"cores"`
-	DiskIOThread      bool             `yaml:"disk_iothread,omitempty"`
-	NUMA              bool             `yaml:"numa,omitempty"`
-	DiskDiscard       bool             `yaml:"disk_discard,omitempty"`
-	DiskSSD           bool             `yaml:"disk_ssd,omitempty"`
+	PlacementStrategy string `yaml:"placement_strategy,omitempty"`
+	// VMIDRange constrains VMID allocation to "start-end" (e.g. "200-250") and,
+	// when set together with network.base_ip, enables VMID-derived static IPs.
+	VMIDRange       string           `yaml:"vmid_range,omitempty"`
+	AdditionalDisks []AdditionalDisk `yaml:"additional_disks,omitempty"`
+	AdditionalNICs  []AdditionalNIC  `yaml:"additional_nics,omitempty"`
+	PCIDevices      []PCIDevice      `yaml:"pci_devices,omitempty"`
+	Tags            []string         `yaml:"tags,omitempty"`
+	Vlan            uint64           `yaml:"vlan"`
+	Memory          uint64           `yaml:"memory"`
+	Sockets         int              `yaml:"sockets"`
+	DiskSize        int              `yaml:"disk_size"`
+	Cores           int              `yaml:"cores"`
+	DiskIOThread    bool             `yaml:"disk_iothread,omitempty"`
+	NUMA            bool             `yaml:"numa,omitempty"`
+	DiskDiscard     bool             `yaml:"disk_discard,omitempty"`
+	DiskSSD         bool             `yaml:"disk_ssd,omitempty"`
 }
 
 // AdditionalDisk represents an additional disk configuration.
@@ -68,4 +74,15 @@ type AdditionalNIC struct {
 	Bridge   string `yaml:"bridge"`             // Network bridge (e.g., vmbr1)
 	Vlan     uint64 `yaml:"vlan,omitempty"`     // Optional VLAN tag
 	Firewall bool   `yaml:"firewall,omitempty"` // Enable firewall (default: false for storage networks)
+}
+
+// NetworkConfig is the optional static-networking block for a provisioned VM.
+// Exactly one of IPAddress (explicit) or BaseIP (VMID-derived, requires
+// Data.VMIDRange) must be set.
+type NetworkConfig struct {
+	Subnet      string   `yaml:"subnet"`                // CIDR, e.g. "192.168.26.0/24"; supplies the prefix
+	Gateway     string   `yaml:"gateway,omitempty"`     // optional default gateway
+	IPAddress   string   `yaml:"ip_address,omitempty"`  // explicit mode: this exact IP
+	BaseIP      string   `yaml:"base_ip,omitempty"`     // derived mode: IP for vmid == range.start
+	Nameservers []string `yaml:"nameservers,omitempty"` // optional DNS servers
 }

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -60,3 +60,34 @@ func (s *scheduler) Release(requestID string) {
 func ShouldCountSetVMs(data Data, hasSet bool) bool {
 	return shouldCountSetVMs(data, hasSet)
 }
+
+func ParseVMIDRange(s string) (start, end int, err error) {
+	r, err := parseVMIDRange(s)
+
+	return r.start, r.end, err
+}
+
+func LowestFreeVMID(start, end int, used map[int]struct{}) (int, error) {
+	return lowestFreeVMID(vmidRange{start: start, end: end}, used)
+}
+
+func ResolveIP(data Data, vmid int) (string, error) {
+	ip, err := resolveIP(data, vmid)
+	if err != nil {
+		return "", err
+	}
+
+	return ip.String(), nil
+}
+
+func ValidateNetwork(data Data) error {
+	return validateNetwork(data)
+}
+
+func ParseMACFromNet(net string) (string, error) {
+	return parseMACFromNet(net)
+}
+
+func BuildNetworkConfig(data Data, vmid int, mac string) (string, error) {
+	return buildNetworkConfig(data, vmid, mac)
+}

--- a/internal/pkg/provider/network.go
+++ b/internal/pkg/provider/network.go
@@ -1,0 +1,240 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"net/netip"
+	"strings"
+)
+
+// netModels are the Proxmox NIC model keys whose value is the MAC address in a
+// net<N> config string (e.g. "virtio=BC:24:11:..."). "macaddr" is the explicit
+// override key.
+var netModels = map[string]struct{}{
+	"virtio": {}, "e1000": {}, "rtl8139": {}, "vmxnet3": {}, "macaddr": {},
+}
+
+// parseMACFromNet extracts the MAC address from a Proxmox net<N> config string
+// such as "virtio=BC:24:11:AA:BB:CC,bridge=vmbr0,firewall=1,tag=2501".
+func parseMACFromNet(net string) (string, error) {
+	for part := range strings.SplitSeq(net, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+
+		if _, isModel := netModels[strings.ToLower(strings.TrimSpace(key))]; isModel {
+			return strings.TrimSpace(value), nil
+		}
+	}
+
+	return "", fmt.Errorf("no MAC address found in net config %q", net)
+}
+
+// addOffset returns addr shifted up by offset (>= 0). It works for both IPv4
+// and IPv6 by doing big-endian arithmetic over the address bytes, and errors if
+// the result no longer fits the address width.
+func addOffset(addr netip.Addr, offset int) (netip.Addr, error) {
+	slice := addr.AsSlice() // 4 bytes for IPv4, 16 for IPv6
+	if len(slice) == 0 {
+		return netip.Addr{}, fmt.Errorf("invalid address %s", addr)
+	}
+
+	sum := new(big.Int).Add(new(big.Int).SetBytes(slice), big.NewInt(int64(offset)))
+
+	raw := sum.Bytes()
+	if len(raw) > len(slice) {
+		return netip.Addr{}, fmt.Errorf("address %s + %d overflows the address space", addr, offset)
+	}
+
+	buf := make([]byte, len(slice))
+	copy(buf[len(slice)-len(raw):], raw) // left-pad to the original width
+
+	out, ok := netip.AddrFromSlice(buf)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("failed to build address from %v", buf)
+	}
+
+	return out, nil
+}
+
+// resolveIP returns the host IP for a VM given its data and assigned vmid.
+// It assumes data.Network != nil (guaranteed by the caller).
+func resolveIP(data Data, vmid int) (netip.Addr, error) {
+	n := data.Network
+
+	if n.IPAddress != "" {
+		addr, err := netip.ParseAddr(n.IPAddress)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("invalid network.ip_address %q: %w", n.IPAddress, err)
+		}
+
+		return addr, nil
+	}
+
+	base, err := netip.ParseAddr(n.BaseIP)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("invalid network.base_ip %q: %w", n.BaseIP, err)
+	}
+
+	r, err := parseVMIDRange(data.VMIDRange)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	return addOffset(base, vmid-r.start)
+}
+
+// validateNetwork validates the optional static-networking block. Nil is valid
+// (DHCP). It performs a whole-range bounds check up front so a misconfigured
+// MachineClass fails immediately rather than only when a high VMID is hit.
+func validateNetwork(data Data) error {
+	n := data.Network
+	if n == nil {
+		return nil
+	}
+
+	prefix, err := netip.ParsePrefix(n.Subnet)
+	if err != nil {
+		return fmt.Errorf("invalid network.subnet %q: %w", n.Subnet, err)
+	}
+
+	if (n.IPAddress == "") == (n.BaseIP == "") {
+		return fmt.Errorf("network requires exactly one of ip_address or base_ip")
+	}
+
+	if n.Gateway != "" {
+		if _, err = netip.ParseAddr(n.Gateway); err != nil {
+			return fmt.Errorf("invalid network.gateway %q: %w", n.Gateway, err)
+		}
+	}
+
+	for _, ns := range n.Nameservers {
+		if _, err = netip.ParseAddr(ns); err != nil {
+			return fmt.Errorf("invalid nameserver %q: %w", ns, err)
+		}
+	}
+
+	if n.IPAddress != "" {
+		ip, parseErr := netip.ParseAddr(n.IPAddress)
+		if parseErr != nil {
+			return fmt.Errorf("invalid network.ip_address %q: %w", n.IPAddress, parseErr)
+		}
+
+		return checkHostIP(prefix, ip)
+	}
+
+	// derived mode
+	if data.VMIDRange == "" {
+		return fmt.Errorf("network.base_ip requires vmid_range")
+	}
+
+	r, err := parseVMIDRange(data.VMIDRange)
+	if err != nil {
+		return err
+	}
+
+	base, err := netip.ParseAddr(n.BaseIP)
+	if err != nil {
+		return fmt.Errorf("invalid network.base_ip %q: %w", n.BaseIP, err)
+	}
+
+	if err = checkHostIP(prefix, base); err != nil {
+		return fmt.Errorf("base_ip: %w", err)
+	}
+
+	top, err := addOffset(base, r.end-r.start)
+	if err != nil {
+		return err
+	}
+
+	if err = checkHostIP(prefix, top); err != nil {
+		return fmt.Errorf("base_ip + vmid_range width leaves the subnet: %w", err)
+	}
+
+	return nil
+}
+
+// checkHostIP ensures ip is inside prefix and is a usable host address. It
+// rejects the network address (IPv4 network / IPv6 subnet-router anycast) and,
+// for IPv4, the broadcast address. A family mismatch between ip and prefix is
+// caught by the containment check (Contains is false across families).
+func checkHostIP(prefix netip.Prefix, ip netip.Addr) error {
+	if !prefix.Contains(ip) {
+		return fmt.Errorf("%s is outside subnet %s", ip, prefix)
+	}
+
+	if prefix.Bits() < ip.BitLen() && ip == prefix.Masked().Addr() {
+		return fmt.Errorf("%s is the network address of %s", ip, prefix)
+	}
+
+	if ip.Is4() && prefix.Bits() <= 30 && ip == broadcastAddr(prefix) {
+		return fmt.Errorf("%s is the broadcast address of %s", ip, prefix)
+	}
+
+	return nil
+}
+
+// broadcastAddr returns the IPv4 broadcast address for prefix.
+func broadcastAddr(prefix netip.Prefix) netip.Addr {
+	b := prefix.Masked().Addr().As4()
+	v := binary.BigEndian.Uint32(b[:]) | (uint32(0xffffffff) >> uint(prefix.Bits()))
+
+	var out [4]byte
+
+	binary.BigEndian.PutUint32(out[:], v)
+
+	return netip.AddrFrom4(out)
+}
+
+// buildNetworkConfig renders a cloud-init network-config v1 document for the
+// primary NIC. It matches the interface by MAC (robust against Talos link-name
+// variability) and encodes the address as <ip>/<prefix>, which Talos nocloud
+// parses via netip.ParsePrefix. Assumes data.Network != nil.
+func buildNetworkConfig(data Data, vmid int, mac string) (string, error) {
+	ip, err := resolveIP(data, vmid)
+	if err != nil {
+		return "", err
+	}
+
+	prefix, err := netip.ParsePrefix(data.Network.Subnet)
+	if err != nil {
+		return "", fmt.Errorf("invalid network.subnet %q: %w", data.Network.Subnet, err)
+	}
+
+	// Talos nocloud selects the address family from the subnet type.
+	subnetType := "static"
+	if !prefix.Addr().Is4() {
+		subnetType = "static6"
+	}
+
+	var b strings.Builder
+
+	b.WriteString("version: 1\n")
+	b.WriteString("config:\n")
+	b.WriteString("  - type: physical\n")
+	fmt.Fprintf(&b, "    mac_address: %s\n", strings.ToLower(mac))
+	b.WriteString("    subnets:\n")
+	fmt.Fprintf(&b, "      - type: %s\n", subnetType)
+	fmt.Fprintf(&b, "        address: %s/%d\n", ip, prefix.Bits())
+
+	if data.Network.Gateway != "" {
+		fmt.Fprintf(&b, "        gateway: %s\n", data.Network.Gateway)
+	}
+
+	if len(data.Network.Nameservers) > 0 {
+		b.WriteString("  - type: nameserver\n")
+		b.WriteString("    address:\n")
+
+		for _, ns := range data.Network.Nameservers {
+			fmt.Fprintf(&b, "      - %s\n", ns)
+		}
+	}
+
+	return b.String(), nil
+}

--- a/internal/pkg/provider/network_test.go
+++ b/internal/pkg/provider/network_test.go
@@ -1,0 +1,374 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni-infra-provider-proxmox/internal/pkg/provider"
+)
+
+func TestParseVMIDRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		start, end  int
+		expectError bool
+	}{
+		{name: "valid", in: "200-250", start: 200, end: 250},
+		{name: "whitespace tolerated", in: " 300 - 310 ", start: 300, end: 310},
+		{name: "single-wide", in: "100-100", start: 100, end: 100},
+		{name: "missing dash", expectError: true, in: "200"},
+		{name: "non-numeric", expectError: true, in: "a-b"},
+		{name: "start below 100", expectError: true, in: "50-60"},
+		{name: "start after end", expectError: true, in: "300-200"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, err := provider.ParseVMIDRange(tt.in)
+			if tt.expectError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.start, start)
+			require.Equal(t, tt.end, end)
+		})
+	}
+}
+
+func TestLowestFreeVMID(t *testing.T) {
+	tests := []struct {
+		used        map[int]struct{}
+		name        string
+		start       int
+		end         int
+		expected    int
+		expectError bool
+	}{
+		{name: "all free picks start", start: 200, end: 250, expected: 200},
+		{
+			name:  "skips used ids",
+			start: 200, end: 250,
+			used:     map[int]struct{}{200: {}, 201: {}},
+			expected: 202,
+		},
+		{
+			name:  "exhausted",
+			start: 200, end: 201,
+			used:        map[int]struct{}{200: {}, 201: {}},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := provider.LowestFreeVMID(tt.start, tt.end, tt.used)
+			if tt.expectError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestResolveIP(t *testing.T) {
+	tests := []struct {
+		data     *provider.Data
+		name     string
+		expected string
+		vmid     int
+	}{
+		{
+			name:     "explicit",
+			expected: "192.168.26.31",
+			vmid:     9999,
+			data: &provider.Data{Network: &provider.NetworkConfig{
+				Subnet:    "192.168.26.0/24",
+				IPAddress: "192.168.26.31",
+			}},
+		},
+		{
+			name:     "derived offset within range",
+			expected: "192.168.26.14",
+			vmid:     5304,
+			data: &provider.Data{
+				VMIDRange: "5300-5350",
+				Network:   &provider.NetworkConfig{Subnet: "192.168.26.0/24", BaseIP: "192.168.26.10"},
+			},
+		},
+		{
+			name:     "derived octet carry",
+			expected: "192.168.1.4",
+			vmid:     210, // offset 10 -> .250 + 10 carries into third octet
+			data: &provider.Data{
+				VMIDRange: "200-400",
+				Network:   &provider.NetworkConfig{Subnet: "192.168.0.0/16", BaseIP: "192.168.0.250"},
+			},
+		},
+		{
+			name:     "ipv6 explicit",
+			expected: "2001:db8::31",
+			vmid:     42,
+			data: &provider.Data{Network: &provider.NetworkConfig{
+				Subnet:    "2001:db8::/64",
+				IPAddress: "2001:db8::31",
+			}},
+		},
+		{
+			name:     "ipv6 derived with carry",
+			expected: "2001:db8::103",
+			vmid:     5304, // offset 4 -> ::ff + 4 = ::103
+			data: &provider.Data{
+				VMIDRange: "5300-5350",
+				Network:   &provider.NetworkConfig{Subnet: "2001:db8::/64", BaseIP: "2001:db8::ff"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := provider.ResolveIP(*tt.data, tt.vmid)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestValidateNetwork(t *testing.T) {
+	valid := func(mut func(*provider.NetworkConfig)) provider.Data {
+		n := &provider.NetworkConfig{Subnet: "192.168.26.0/24", Gateway: "192.168.26.1", IPAddress: "192.168.26.31"}
+		if mut != nil {
+			mut(n)
+		}
+
+		return provider.Data{Network: n}
+	}
+
+	tests := []struct {
+		name        string
+		data        provider.Data
+		expectError bool
+	}{
+		{name: "nil network is fine", data: provider.Data{}},
+		{name: "valid explicit", data: valid(nil)},
+		{
+			name: "valid derived",
+			data: provider.Data{
+				VMIDRange: "5300-5350",
+				Network:   &provider.NetworkConfig{Subnet: "192.168.26.0/24", BaseIP: "192.168.26.10"},
+			},
+		},
+		{
+			name: "valid ipv6 explicit",
+			data: provider.Data{Network: &provider.NetworkConfig{
+				Subnet:      "2001:db8::/64",
+				Gateway:     "2001:db8::1",
+				Nameservers: []string{"2001:4860:4860::8888"},
+				IPAddress:   "2001:db8::31",
+			}},
+		},
+		{
+			name: "valid ipv6 derived",
+			data: provider.Data{
+				VMIDRange: "5300-5350",
+				Network:   &provider.NetworkConfig{Subnet: "2001:db8::/64", BaseIP: "2001:db8::10"},
+			},
+		},
+		{
+			name:        "ipv6 ip is subnet-router anycast",
+			expectError: true,
+			data:        provider.Data{Network: &provider.NetworkConfig{Subnet: "2001:db8::/64", IPAddress: "2001:db8::"}},
+		},
+		{
+			name:        "ipv6 ip outside subnet",
+			expectError: true,
+			data:        provider.Data{Network: &provider.NetworkConfig{Subnet: "2001:db8::/64", IPAddress: "2001:dead::5"}},
+		},
+		{
+			name:        "family mismatch: v4 subnet, v6 ip",
+			expectError: true,
+			data:        valid(func(n *provider.NetworkConfig) { n.IPAddress = "2001:db8::5" }),
+		},
+		{name: "missing subnet", expectError: true, data: valid(func(n *provider.NetworkConfig) { n.Subnet = "" })},
+		{name: "bad subnet", expectError: true, data: valid(func(n *provider.NetworkConfig) { n.Subnet = "192.168.26.0" })},
+		{
+			name:        "both ip_address and base_ip",
+			expectError: true,
+			data:        valid(func(n *provider.NetworkConfig) { n.BaseIP = "192.168.26.10" }),
+		},
+		{
+			name:        "neither ip_address nor base_ip",
+			expectError: true,
+			data:        valid(func(n *provider.NetworkConfig) { n.IPAddress = "" }),
+		},
+		{
+			name:        "base_ip without vmid_range",
+			expectError: true,
+			data:        provider.Data{Network: &provider.NetworkConfig{Subnet: "192.168.26.0/24", BaseIP: "192.168.26.10"}},
+		},
+		{
+			name:        "explicit ip outside subnet",
+			expectError: true,
+			data:        valid(func(n *provider.NetworkConfig) { n.IPAddress = "10.0.0.5" }),
+		},
+		{
+			name:        "explicit ip is network address",
+			expectError: true,
+			data:        valid(func(n *provider.NetworkConfig) { n.IPAddress = "192.168.26.0" }),
+		},
+		{
+			name:        "explicit ip is broadcast address",
+			expectError: true,
+			data:        valid(func(n *provider.NetworkConfig) { n.IPAddress = "192.168.26.255" }),
+		},
+		{
+			name:        "derived range width leaves subnet",
+			expectError: true,
+			data: provider.Data{
+				VMIDRange: "5300-5350",                                                                  // width 50
+				Network:   &provider.NetworkConfig{Subnet: "192.168.26.0/24", BaseIP: "192.168.26.230"}, // 230+50=280
+			},
+		},
+		{name: "bad gateway", expectError: true, data: valid(func(n *provider.NetworkConfig) { n.Gateway = "nope" })},
+		{name: "bad nameserver", expectError: true, data: valid(func(n *provider.NetworkConfig) { n.Nameservers = []string{"8.8.8.8", "x"} })},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := provider.ValidateNetwork(tt.data)
+			if tt.expectError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestParseMACFromNet(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "virtio with trailing options",
+			in:       "virtio=BC:24:11:AA:BB:CC,bridge=vmbr0,firewall=1,tag=2501",
+			expected: "BC:24:11:AA:BB:CC",
+		},
+		{
+			name:     "e1000 model",
+			in:       "e1000=DE:AD:BE:EF:00:01,bridge=vmbr1",
+			expected: "DE:AD:BE:EF:00:01",
+		},
+		{name: "no mac present", expectError: true, in: "bridge=vmbr0,firewall=1"},
+		{name: "empty", expectError: true, in: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := provider.ParseMACFromNet(tt.in)
+			if tt.expectError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBuildNetworkConfig(t *testing.T) {
+	t.Run("explicit with gateway and nameservers", func(t *testing.T) {
+		data := provider.Data{Network: &provider.NetworkConfig{
+			Subnet:      "192.168.26.0/24",
+			Gateway:     "192.168.26.1",
+			Nameservers: []string{"8.8.8.8", "8.8.4.4"},
+			IPAddress:   "192.168.26.31",
+		}}
+
+		got, err := provider.BuildNetworkConfig(data, 0, "BC:24:11:AA:BB:CC")
+		require.NoError(t, err)
+
+		expected := `version: 1
+config:
+  - type: physical
+    mac_address: bc:24:11:aa:bb:cc
+    subnets:
+      - type: static
+        address: 192.168.26.31/24
+        gateway: 192.168.26.1
+  - type: nameserver
+    address:
+      - 8.8.8.8
+      - 8.8.4.4
+`
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("derived without gateway or nameservers", func(t *testing.T) {
+		data := provider.Data{
+			VMIDRange: "5300-5350",
+			Network:   &provider.NetworkConfig{Subnet: "192.168.26.0/24", BaseIP: "192.168.26.10"},
+		}
+
+		got, err := provider.BuildNetworkConfig(data, 5304, "bc:24:11:aa:bb:cc")
+		require.NoError(t, err)
+
+		expected := `version: 1
+config:
+  - type: physical
+    mac_address: bc:24:11:aa:bb:cc
+    subnets:
+      - type: static
+        address: 192.168.26.14/24
+`
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("ipv6 emits static6", func(t *testing.T) {
+		data := provider.Data{
+			VMIDRange: "5300-5350",
+			Network: &provider.NetworkConfig{
+				Subnet:      "2001:db8::/64",
+				Gateway:     "2001:db8::1",
+				Nameservers: []string{"2001:4860:4860::8888"},
+				BaseIP:      "2001:db8::10",
+			},
+		}
+
+		got, err := provider.BuildNetworkConfig(data, 5304, "bc:24:11:aa:bb:cc")
+		require.NoError(t, err)
+
+		expected := `version: 1
+config:
+  - type: physical
+    mac_address: bc:24:11:aa:bb:cc
+    subnets:
+      - type: static6
+        address: 2001:db8::14/64
+        gateway: 2001:db8::1
+  - type: nameserver
+    address:
+      - 2001:4860:4860::8888
+`
+		require.Equal(t, expected, got)
+	})
+}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -42,8 +42,10 @@ type Provisioner struct {
 	proxmoxClient         *proxmox.Client
 	scheduler             *scheduler
 	pendingISODownloads   map[string]string
+	reservedVMIDs         map[int]struct{}
 	pendingISODownloadsMu sync.Mutex
 	poolMu                sync.Mutex
+	vmidMu                sync.Mutex
 }
 
 // NewProvisioner creates a new provisioner.
@@ -53,6 +55,7 @@ func NewProvisioner(proxmoxClient *proxmox.Client) *Provisioner {
 		scheduler:           newScheduler(),
 		ha:                  ha.NewManager(proxmoxClient),
 		pendingISODownloads: make(map[string]string),
+		reservedVMIDs:       make(map[int]struct{}),
 	}
 }
 
@@ -312,6 +315,10 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return err
 			}
 
+			if err = validateNetwork(data); err != nil {
+				return err
+			}
+
 			node, err := p.proxmoxClient.Node(ctx, pctx.State.TypedSpec().Value.Node)
 			if err != nil {
 				return err
@@ -322,9 +329,31 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return err
 			}
 
-			vmid, err := cluster.NextID(ctx)
+			var vmid int
+
+			if data.VMIDRange != "" {
+				vmid, err = p.allocateVMID(ctx, cluster, data.VMIDRange)
+			} else {
+				vmid, err = cluster.NextID(ctx)
+			}
+
 			if err != nil {
 				return err
+			}
+
+			// Release the reservation on any early return between here and a
+			// successful VM creation. A created VM keeps its reservation so the
+			// id stays reserved until it materializes in cluster.Resources and
+			// self-prunes. The NextID (empty-range) path never reserves, so the
+			// guard skips it.
+			committed := false
+
+			if data.VMIDRange != "" {
+				defer func() {
+					if !committed {
+						p.releaseVMID(vmid)
+					}
+				}()
 			}
 
 			isoStorage, err := node.StorageISO(ctx)
@@ -606,6 +635,8 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return err
 			}
 
+			committed = true
+
 			pctx.State.TypedSpec().Value.VmCreateTask = string(task.UPID)
 			pctx.State.TypedSpec().Value.Vmid = int32(vmid)
 
@@ -622,6 +653,31 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					return err
 				}
 
+				var data Data
+
+				if err = pctx.UnmarshalProviderData(&data); err != nil {
+					return err
+				}
+
+				networkConfig := "version: 1"
+
+				if data.Network != nil {
+					netCfg, ok := vm.VirtualMachineConfig.Nets["net0"]
+					if !ok {
+						return fmt.Errorf("net0 config not found on VM %d", pctx.State.TypedSpec().Value.Vmid)
+					}
+
+					mac, macErr := parseMACFromNet(netCfg)
+					if macErr != nil {
+						return macErr
+					}
+
+					networkConfig, err = buildNetworkConfig(data, int(pctx.State.TypedSpec().Value.Vmid), mac)
+					if err != nil {
+						return err
+					}
+				}
+
 				err = vm.CloudInit(
 					ctx,
 					"ide0",
@@ -635,7 +691,7 @@ hostname: %s`,
 						pctx.GetRequestID(),
 					),
 					"",
-					"version: 1",
+					networkConfig,
 				)
 				if err != nil {
 					return fmt.Errorf("failed to inject nocloud config: %w", err)
@@ -663,6 +719,10 @@ func (p *Provisioner) Deprovision(ctx context.Context, logger *zap.Logger, machi
 	// release up front: a request torn down before its VM materializes returns
 	// at the Vmid == 0 check below.
 	p.scheduler.release(machineRequest.Metadata().ID())
+
+	// release any VMID reservation held in-memory for this machine; no-op if it
+	// was never range-allocated or already self-pruned after materializing.
+	p.releaseVMID(int(machine.TypedSpec().Value.Vmid))
 
 	if machine.TypedSpec().Value.Vmid == 0 {
 		return nil
@@ -741,6 +801,58 @@ func (p *Provisioner) Deprovision(ctx context.Context, logger *zap.Logger, machi
 	}
 
 	return nil
+}
+
+// allocateVMID picks the lowest free VMID within rangeSpec. It combines the
+// cluster's in-use VMIDs with an in-memory reserved-set so concurrent
+// provisions in the same set do not collide during the window between
+// allocation and the VM appearing in Proxmox. Reserved IDs self-prune once they
+// materialize in the cluster resource list.
+func (p *Provisioner) allocateVMID(ctx context.Context, cluster *proxmox.Cluster, rangeSpec string) (int, error) {
+	r, err := parseVMIDRange(rangeSpec)
+	if err != nil {
+		return 0, err
+	}
+
+	vmResources, err := cluster.Resources(ctx, "vm")
+	if err != nil {
+		return 0, fmt.Errorf("failed to list cluster resources: %w", err)
+	}
+
+	p.vmidMu.Lock()
+	defer p.vmidMu.Unlock()
+
+	used := make(map[int]struct{}, len(vmResources)+len(p.reservedVMIDs))
+	for _, res := range vmResources {
+		used[int(res.VMID)] = struct{}{}
+	}
+
+	for id := range p.reservedVMIDs {
+		if _, materialized := used[id]; materialized {
+			delete(p.reservedVMIDs, id)
+
+			continue
+		}
+
+		used[id] = struct{}{}
+	}
+
+	id, err := lowestFreeVMID(r, used)
+	if err != nil {
+		return 0, err
+	}
+
+	p.reservedVMIDs[id] = struct{}{}
+
+	return id, nil
+}
+
+// releaseVMID drops an id from the reserved-set (used when VM creation fails).
+func (p *Provisioner) releaseVMID(id int) {
+	p.vmidMu.Lock()
+	defer p.vmidMu.Unlock()
+
+	delete(p.reservedVMIDs, id)
 }
 
 // User tags come first so the tags string is stable across reconciles.

--- a/internal/pkg/provider/vmid.go
+++ b/internal/pkg/provider/vmid.go
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// vmidRange is an inclusive [start, end] range of Proxmox VMIDs.
+type vmidRange struct {
+	start int
+	end   int
+}
+
+// parseVMIDRange parses a "start-end" string (e.g. "200-250").
+func parseVMIDRange(s string) (vmidRange, error) {
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) != 2 {
+		return vmidRange{}, fmt.Errorf("invalid vmid_range %q: expected \"start-end\"", s)
+	}
+
+	start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return vmidRange{}, fmt.Errorf("invalid vmid_range start %q: %w", parts[0], err)
+	}
+
+	end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return vmidRange{}, fmt.Errorf("invalid vmid_range end %q: %w", parts[1], err)
+	}
+
+	if start < 100 {
+		return vmidRange{}, fmt.Errorf("invalid vmid_range %q: start must be >= 100", s)
+	}
+
+	if start > end {
+		return vmidRange{}, fmt.Errorf("invalid vmid_range %q: start must be <= end", s)
+	}
+
+	return vmidRange{start: start, end: end}, nil
+}
+
+// lowestFreeVMID returns the lowest id in the range that is not present in used.
+func lowestFreeVMID(r vmidRange, used map[int]struct{}) (int, error) {
+	for id := r.start; id <= r.end; id++ {
+		if _, taken := used[id]; !taken {
+			return id, nil
+		}
+	}
+
+	return 0, fmt.Errorf("vmid_range %d-%d exhausted: no free VMID available", r.start, r.end)
+}


### PR DESCRIPTION
## Summary

Closes #70. Adds optional static networking to the Proxmox infra provider.

Today the provider hardcodes the cloud-init network-config to `version: 1`
(DHCP), so VMs can't be provisioned in environments without DHCP. This adds an
optional `network:` block to the machine-class `providerdata`; when present the
provider builds a cloud-init **network-config v1** document and injects it in
place of the DHCP default. When absent, behavior is unchanged (DHCP).

## Addressing modes

- **Explicit** — a fixed `ip_address` (single-machine classes / a specific control-plane node).
- **VMID-derived** — `vmid_range` + `base_ip`, where `ip = base_ip + (vmid - range.start)`.
  The provider allocates each VM's VMID from `vmid_range` (lowest-free, guarded by a
  concurrency-safe reserved-set), so every machine in a set gets a unique, deterministic
  IP. This solves the shared-`providerdata` collision problem.

Both **IPv4 and IPv6** are supported (single-family per class, inferred from the
`subnet` CIDR; IPv6 emits `type: static6`). Dual-stack is intentionally out of scope.

## Example

```yaml
providerdata: |
  storage_selector: name == "local-lvm"
  network_bridge: vmbr1
  vlan: 2501
  vmid_range: 5300-5350
  network:
    subnet: 192.168.26.0/24
    gateway: 192.168.26.1
    nameservers: [8.8.8.8, 8.8.4.4]
    base_ip: 192.168.26.10   # vmid 5300 -> .10, 5304 -> .14
```

## What changed

- `data.go` — optional `network:` block + `vmid_range`.
- `network.go` / `vmid.go` — pure, unit-tested helpers: VMID-range parse + lowest-free
  allocation, family-agnostic IP offset (IPv4+IPv6), up-front validation, MAC parsing,
  and the network-config v1 builder.
- `provision.go` — `syncVM` allocates VMIDs from the range (concurrency-safe, and
  leak-free across step retries **and** deprovision); `startVM` injects the built config,
  matching the NIC by the read-back `net0` MAC (robust against Talos link-name variability).
- `data/schema.json` — declares `vmid_range` + `network` so the fields render in the Omni UI.
- `README.md` — Static Networking docs (explicit + derived, IPv6, caveats).

## Validation (fails the machine class up front)

`subnet` required (CIDR); exactly one of `ip_address`/`base_ip`; `base_ip` requires
`vmid_range`; the whole `base_ip … base_ip + (range width)` must fit inside `subnet`;
network/broadcast (IPv4) and network / subnet-router-anycast (IPv6) rejected.

## Testing / verification

- Unit: table-driven cases across the new helpers; `go test ./...`, `go vet ./...`, and
  `golangci-lint run ./...` all clean.
- Live: built the provider and registered it against a real Omni instance; confirmed the
  new schema fields render in the Omni UI; validated the `net0` MAC read-back and token
  auth against a live Proxmox 9.2 cluster.

## Notes / follow-ups

- Backward compatible: no `network:` block → DHCP, exactly as before.
- Additional-NIC (`net1+`) static addressing is out of scope here (primary NIC only).
- Deferred: the `allocateVMID` self-prune bookkeeping isn't unit-tested yet (coupled to a
  live `cluster.Resources` call; extractable into a pure helper later).
