### PR TITLE
Stamp the picked Proxmox host onto the machine as a node label

### DIFF
--- a/.github/workflows/fork-image.yaml
+++ b/.github/workflows/fork-image.yaml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   image:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fork-image.yaml
+++ b/.github/workflows/fork-image.yaml
@@ -1,0 +1,32 @@
+name: fork-image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        env:
+          PLATFORM: linux/amd64,linux/arm64
+          PUSH: "true"
+          USERNAME: ${{ github.repository_owner }}
+        run: make image-omni-infra-provider-proxmox IMAGE_TAG=latest

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -9,29 +9,32 @@ type Data struct {
 	Balloon *bool `yaml:"balloon,omitempty"`
 	// NetworkFirewall enables the per-VM firewall (fwbr) on the primary NIC.
 	// Defaults to true. Set false when L2-broadcast services need traffic to bypass fwbr.
-	NetworkFirewall *bool            `yaml:"network_firewall,omitempty"`
-	Node            string           `yaml:"node,omitempty"`
-	StorageSelector string           `yaml:"storage_selector,omitempty"`
-	NetworkBridge   string           `yaml:"network_bridge"`
-	Hugepages       string           `yaml:"hugepages,omitempty"`
-	MachineType     string           `yaml:"machine_type,omitempty"`
-	CPUType         string           `yaml:"cpu_type,omitempty"`
-	DiskAIO         string           `yaml:"disk_aio,omitempty"`
-	DiskCache       string           `yaml:"disk_cache,omitempty"`
-	Pool            string           `yaml:"pool,omitempty"`
-	AdditionalDisks []AdditionalDisk `yaml:"additional_disks,omitempty"`
-	AdditionalNICs  []AdditionalNIC  `yaml:"additional_nics,omitempty"`
-	PCIDevices      []PCIDevice      `yaml:"pci_devices,omitempty"`
-	Tags            []string         `yaml:"tags,omitempty"`
-	Vlan            uint64           `yaml:"vlan"`
-	Memory          uint64           `yaml:"memory"`
-	Sockets         int              `yaml:"sockets"`
-	DiskSize        int              `yaml:"disk_size"`
-	Cores           int              `yaml:"cores"`
-	DiskIOThread    bool             `yaml:"disk_iothread,omitempty"`
-	NUMA            bool             `yaml:"numa,omitempty"`
-	DiskDiscard     bool             `yaml:"disk_discard,omitempty"`
-	DiskSSD         bool             `yaml:"disk_ssd,omitempty"`
+	NetworkFirewall *bool  `yaml:"network_firewall,omitempty"`
+	Node            string `yaml:"node,omitempty"`
+	StorageSelector string `yaml:"storage_selector,omitempty"`
+	NetworkBridge   string `yaml:"network_bridge"`
+	Hugepages       string `yaml:"hugepages,omitempty"`
+	MachineType     string `yaml:"machine_type,omitempty"`
+	CPUType         string `yaml:"cpu_type,omitempty"`
+	DiskAIO         string `yaml:"disk_aio,omitempty"`
+	DiskCache       string `yaml:"disk_cache,omitempty"`
+	Pool            string `yaml:"pool,omitempty"`
+	// PlacementStrategy selects how a node is chosen for an auto-provisioned VM:
+	// spread (default), fewer-vms, round-robin or binpack.
+	PlacementStrategy string           `yaml:"placement_strategy,omitempty"`
+	AdditionalDisks   []AdditionalDisk `yaml:"additional_disks,omitempty"`
+	AdditionalNICs    []AdditionalNIC  `yaml:"additional_nics,omitempty"`
+	PCIDevices        []PCIDevice      `yaml:"pci_devices,omitempty"`
+	Tags              []string         `yaml:"tags,omitempty"`
+	Vlan              uint64           `yaml:"vlan"`
+	Memory            uint64           `yaml:"memory"`
+	Sockets           int              `yaml:"sockets"`
+	DiskSize          int              `yaml:"disk_size"`
+	Cores             int              `yaml:"cores"`
+	DiskIOThread      bool             `yaml:"disk_iothread,omitempty"`
+	NUMA              bool             `yaml:"numa,omitempty"`
+	DiskDiscard       bool             `yaml:"disk_discard,omitempty"`
+	DiskSSD           bool             `yaml:"disk_ssd,omitempty"`
 }
 
 // AdditionalDisk represents an additional disk configuration.

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -21,20 +21,26 @@ type Data struct {
 	Pool            string `yaml:"pool,omitempty"`
 	// PlacementStrategy selects how a node is chosen for an auto-provisioned VM:
 	// spread (default), fewer-vms, round-robin or binpack.
-	PlacementStrategy string           `yaml:"placement_strategy,omitempty"`
-	AdditionalDisks   []AdditionalDisk `yaml:"additional_disks,omitempty"`
-	AdditionalNICs    []AdditionalNIC  `yaml:"additional_nics,omitempty"`
-	PCIDevices        []PCIDevice      `yaml:"pci_devices,omitempty"`
-	Tags              []string         `yaml:"tags,omitempty"`
-	Vlan              uint64           `yaml:"vlan"`
-	Memory            uint64           `yaml:"memory"`
-	Sockets           int              `yaml:"sockets"`
-	DiskSize          int              `yaml:"disk_size"`
-	Cores             int              `yaml:"cores"`
-	DiskIOThread      bool             `yaml:"disk_iothread,omitempty"`
-	NUMA              bool             `yaml:"numa,omitempty"`
-	DiskDiscard       bool             `yaml:"disk_discard,omitempty"`
-	DiskSSD           bool             `yaml:"disk_ssd,omitempty"`
+	PlacementStrategy string `yaml:"placement_strategy,omitempty"`
+	// IPAllocation selects how a VM gets its address: dhcp (default) or
+	// deterministic (a static address derived from the VM id within subnet).
+	IPAllocation    string           `yaml:"ip_allocation,omitempty"`
+	Subnet          string           `yaml:"subnet,omitempty"`
+	Gateway         string           `yaml:"gateway,omitempty"`
+	AdditionalDisks []AdditionalDisk `yaml:"additional_disks,omitempty"`
+	AdditionalNICs  []AdditionalNIC  `yaml:"additional_nics,omitempty"`
+	PCIDevices      []PCIDevice      `yaml:"pci_devices,omitempty"`
+	Tags            []string         `yaml:"tags,omitempty"`
+	DNSServers      []string         `yaml:"dns_servers,omitempty"`
+	Vlan            uint64           `yaml:"vlan"`
+	Memory          uint64           `yaml:"memory"`
+	Sockets         int              `yaml:"sockets"`
+	DiskSize        int              `yaml:"disk_size"`
+	Cores           int              `yaml:"cores"`
+	DiskIOThread    bool             `yaml:"disk_iothread,omitempty"`
+	NUMA            bool             `yaml:"numa,omitempty"`
+	DiskDiscard     bool             `yaml:"disk_discard,omitempty"`
+	DiskSSD         bool             `yaml:"disk_ssd,omitempty"`
 }
 
 // AdditionalDisk represents an additional disk configuration.

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -4,6 +4,8 @@
 
 package provider
 
+import "time"
+
 type NodeStatus = nodeStatus
 
 func PickNode(nodes []NodeStatus) NodeStatus {
@@ -16,4 +18,18 @@ func BuildTagsOption(userTags []string, machineRequestSet string) (string, bool)
 
 func PoolCreateDecision(exists bool, poolID, machineRequestSet string) (bool, error) {
 	return poolCreateDecision(exists, poolID, machineRequestSet)
+}
+
+type Scheduler = scheduler
+
+func NewScheduler() *Scheduler {
+	return newScheduler()
+}
+
+func NewSchedulerWithClock(now func() time.Time, ttl time.Duration) *Scheduler {
+	return newSchedulerWithClock(now, ttl)
+}
+
+func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, materialized map[string]struct{}) NodeStatus {
+	return s.pick(nodes, set, requestID, materialized)
 }

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -4,7 +4,10 @@
 
 package provider
 
-import "time"
+import (
+	"net/netip"
+	"time"
+)
 
 type NodeStatus = nodeStatus
 
@@ -40,4 +43,23 @@ func ParseStrategy(s string) (string, error) {
 	strat, err := parseStrategy(s)
 
 	return string(strat), err
+}
+
+func ParseIPAllocation(s string) (string, error) {
+	alloc, err := parseIPAllocation(s)
+
+	return string(alloc), err
+}
+
+func AllocateIP(mode string, subnet netip.Prefix, vmid int) (netip.Addr, bool, error) {
+	alloc, err := parseIPAllocation(mode)
+	if err != nil {
+		return netip.Addr{}, false, err
+	}
+
+	return allocateIP(alloc, subnet, vmid)
+}
+
+func BuildNetworkConfig(addr, gateway string, dns []string) string {
+	return buildNetworkConfig(addr, gateway, dns)
 }

--- a/internal/pkg/provider/export_test.go
+++ b/internal/pkg/provider/export_test.go
@@ -30,6 +30,14 @@ func NewSchedulerWithClock(now func() time.Time, ttl time.Duration) *Scheduler {
 	return newSchedulerWithClock(now, ttl)
 }
 
-func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, materialized map[string]struct{}) NodeStatus {
-	return s.pick(nodes, set, requestID, materialized)
+func (s *scheduler) Pick(nodes []NodeStatus, set, requestID string, memory uint64, strategy string, materialized map[string]struct{}) NodeStatus {
+	strat, _ := parseStrategy(strategy)
+
+	return s.pick(nodes, set, requestID, memory, strat, materialized)
+}
+
+func ParseStrategy(s string) (string, error) {
+	strat, err := parseStrategy(s)
+
+	return string(strat), err
 }

--- a/internal/pkg/provider/ipalloc.go
+++ b/internal/pkg/provider/ipalloc.go
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+type ipAllocation string
+
+const (
+	ipDHCP          ipAllocation = "dhcp"
+	ipDeterministic ipAllocation = "deterministic"
+)
+
+func parseIPAllocation(s string) (ipAllocation, error) {
+	switch ipAllocation(s) {
+	case "", ipDHCP:
+		return ipDHCP, nil
+	case ipDeterministic:
+		return ipDeterministic, nil
+	default:
+		return "", fmt.Errorf("unknown ip allocation %q", s)
+	}
+}
+
+// allocateIP returns the address a VM should use under the given mode, or
+// ok=false for dhcp. deterministic derives a stable host from the VM id, which
+// is unique per VM so addresses never collide.
+func allocateIP(mode ipAllocation, subnet netip.Prefix, vmid int) (netip.Addr, bool, error) {
+	if mode == ipDHCP {
+		return netip.Addr{}, false, nil
+	}
+
+	if !subnet.Addr().Is4() {
+		return netip.Addr{}, false, fmt.Errorf("ip allocation requires an IPv4 subnet, got %q", subnet)
+	}
+
+	if subnet.Bits() > 30 {
+		return netip.Addr{}, false, fmt.Errorf("subnet %q is too small for host allocation", subnet)
+	}
+
+	base := subnet.Masked().Addr().As4()
+	network := binary.BigEndian.Uint32(base[:])
+	maxHosts := (uint32(1) << (32 - subnet.Bits())) - 2
+
+	host := uint32(vmid) % maxHosts
+	if host == 0 {
+		host = maxHosts
+	}
+
+	var b [4]byte
+
+	binary.BigEndian.PutUint32(b[:], network+host)
+
+	return netip.AddrFrom4(b), true, nil
+}
+
+// buildNetworkConfig renders a cloud-init v1 network-config for a static address,
+// consumed by Talos nocloud so the node has its address before it reaches Omni.
+func buildNetworkConfig(addr, gateway string, dns []string) string {
+	var b strings.Builder
+
+	b.WriteString("version: 1\n")
+	b.WriteString("config:\n")
+	b.WriteString("  - type: physical\n")
+	b.WriteString("    name: eth0\n")
+	b.WriteString("    subnets:\n")
+	b.WriteString("      - type: static\n")
+	fmt.Fprintf(&b, "        address: %s\n", addr)
+	fmt.Fprintf(&b, "        gateway: %s\n", gateway)
+
+	if len(dns) > 0 {
+		b.WriteString("  - type: nameserver\n")
+		b.WriteString("    address:\n")
+
+		for _, ns := range dns {
+			fmt.Fprintf(&b, "      - %s\n", ns)
+		}
+	}
+
+	return b.String()
+}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -38,6 +38,7 @@ const (
 // Provisioner implements Talos emulator infra provider.
 type Provisioner struct {
 	proxmoxClient         *proxmox.Client
+	scheduler             *scheduler
 	pendingISODownloads   map[string]string
 	pendingISODownloadsMu sync.Mutex
 	poolMu                sync.Mutex
@@ -47,6 +48,7 @@ type Provisioner struct {
 func NewProvisioner(proxmoxClient *proxmox.Client) *Provisioner {
 	return &Provisioner{
 		proxmoxClient:       proxmoxClient,
+		scheduler:           newScheduler(),
 		pendingISODownloads: make(map[string]string),
 	}
 }
@@ -57,6 +59,10 @@ func NewProvisioner(proxmoxClient *proxmox.Client) *Provisioner {
 func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 	return []provision.Step[*resources.Machine]{
 		provision.NewStep("pickNode", func(ctx context.Context, logger *zap.Logger, pctx provision.Context[*resources.Machine]) error {
+			if pctx.State.TypedSpec().Value.Node != "" {
+				return nil
+			}
+
 			var data Data
 
 			if err := pctx.UnmarshalProviderData(&data); err != nil {
@@ -91,7 +97,10 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return fmt.Errorf("specified node %q not found in cluster", data.Node)
 			}
 
+			machineRequestSet, inSet := pctx.GetMachineRequestSetID()
+
 			nodeInfoList := make([]nodeStatus, 0, len(nodes))
+			materialized := map[string]struct{}{}
 
 			for _, node := range nodes {
 				// Skip nodes that are not online to avoid Proxmox API errors
@@ -106,7 +115,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				ns.Name = node.Node
 				ns.MemoryFree = float64(node.MaxMem-node.Mem) / float64(node.MaxMem)
 
-				if machineRequestSet, ok := pctx.GetMachineRequestSetID(); ok {
+				if inSet {
 					n, err := p.proxmoxClient.Node(ctx, node.Node)
 					if err != nil {
 						return fmt.Errorf("failed to get node %q, %w", node.Node, err)
@@ -114,12 +123,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 					vms, err := n.VirtualMachines(ctx)
 					if err != nil {
-						return fmt.Errorf("failed to get vms for now %q, %w", node.Node, err)
+						return fmt.Errorf("failed to get vms for node %q, %w", node.Node, err)
 					}
 
 					for _, vm := range vms {
 						if vm.HasTag(machineRequestTagPrefix + machineRequestSet) {
-							ns.SameMachineRequestSetVMs += 1
+							ns.SameMachineRequestSetVMs++
+							materialized[vm.Name] = struct{}{}
 						}
 					}
 				}
@@ -131,7 +141,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return fmt.Errorf("no online nodes available for provisioning")
 			}
 
-			pickedNode := pickNode(nodeInfoList)
+			var pickedNode nodeStatus
+
+			if inSet {
+				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), materialized)
+			} else {
+				pickedNode = pickNode(nodeInfoList)
+			}
 
 			pctx.State.TypedSpec().Value.Node = pickedNode.Name
 

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -69,6 +69,11 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				return err
 			}
 
+			strat, err := parseStrategy(data.PlacementStrategy)
+			if err != nil {
+				return err
+			}
+
 			nodes, err := p.proxmoxClient.Nodes(ctx)
 			if err != nil {
 				return err
@@ -115,6 +120,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				ns.Name = node.Node
 				ns.MemoryFree = float64(node.MaxMem-node.Mem) / float64(node.MaxMem)
 
+				// FreeMem is unsigned; guard the subtraction in case Proxmox ever
+				// reports used memory above the node total.
+				// (hopefully that stray universal electron and caffeinated devs won't ever cause this)
+				if node.MaxMem > node.Mem {
+					ns.FreeMem = node.MaxMem - node.Mem
+				}
+
 				if inSet {
 					n, err := p.proxmoxClient.Node(ctx, node.Node)
 					if err != nil {
@@ -125,6 +137,8 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					if err != nil {
 						return fmt.Errorf("failed to get vms for node %q, %w", node.Node, err)
 					}
+
+					ns.TotalVMs = len(vms)
 
 					for _, vm := range vms {
 						if vm.HasTag(machineRequestTagPrefix + machineRequestSet) {
@@ -144,7 +158,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			var pickedNode nodeStatus
 
 			if inSet {
-				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), materialized)
+				pickedNode = p.scheduler.pick(nodeInfoList, machineRequestSet, pctx.GetRequestID(), data.Memory*1024*1024, strat, materialized)
 			} else {
 				pickedNode = pickNode(nodeInfoList)
 			}
@@ -865,7 +879,9 @@ func (p *Provisioner) waitForTaskToFinish(ctx context.Context, t *proxmox.Task) 
 type nodeStatus struct {
 	Name                     string
 	MemoryFree               float64
+	FreeMem                  uint64
 	SameMachineRequestSetVMs int
+	TotalVMs                 int
 }
 
 func pickNode(nodeInfoList []nodeStatus) nodeStatus {

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/netip"
 	"net/url"
 	"slices"
 	"strings"
@@ -606,6 +607,11 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					return err
 				}
 
+				networkConfig, err := networkConfigFor(pctx)
+				if err != nil {
+					return err
+				}
+
 				err = vm.CloudInit(
 					ctx,
 					"ide0",
@@ -618,7 +624,7 @@ hostname: %s`,
 						pctx.GetRequestID(),
 						pctx.GetRequestID(),
 					),
-					"",
+					networkConfig,
 					"version: 1",
 				)
 				if err != nil {
@@ -638,6 +644,45 @@ hostname: %s`,
 			return nil
 		}),
 	}
+}
+
+// networkConfigFor renders the cloud-init network-config for a machine, or an
+// empty string when the machine uses DHCP.
+func networkConfigFor(pctx provision.Context[*resources.Machine]) (string, error) {
+	var data Data
+
+	if err := pctx.UnmarshalProviderData(&data); err != nil {
+		return "", err
+	}
+
+	mode, err := parseIPAllocation(data.IPAllocation)
+	if err != nil {
+		return "", err
+	}
+
+	if mode == ipDHCP {
+		return "", nil
+	}
+
+	if data.Subnet == "" || data.Gateway == "" {
+		return "", fmt.Errorf("ip allocation %q requires subnet and gateway", mode)
+	}
+
+	subnet, err := netip.ParsePrefix(data.Subnet)
+	if err != nil {
+		return "", fmt.Errorf("invalid subnet %q: %w", data.Subnet, err)
+	}
+
+	addr, ok, err := allocateIP(mode, subnet, int(pctx.State.TypedSpec().Value.Vmid))
+	if err != nil {
+		return "", err
+	}
+
+	if !ok {
+		return "", nil
+	}
+
+	return buildNetworkConfig(fmt.Sprintf("%s/%d", addr, subnet.Bits()), data.Gateway, data.DNSServers), nil
 }
 
 // Deprovision implements infra.Provisioner.

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -6,6 +6,7 @@ package provider_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -171,4 +172,60 @@ func TestBuildTagsOption(t *testing.T) {
 			require.Equal(t, tt.expectedValue, value)
 		})
 	}
+}
+
+func TestSchedulerSpreadsInFlightPlacements(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 0.9},
+			{Name: "node-b", MemoryFree: 0.8},
+			{Name: "node-c", MemoryFree: 0.7},
+		}
+	}
+
+	var picked []string
+
+	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
+		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, nil).Name)
+	}
+
+	require.ElementsMatch(t, []string{"node-a", "node-b", "node-c"}, picked)
+}
+
+func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
+	s := provider.NewScheduler()
+
+	twoNodes := func(proxmoxOnA int) []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 1.0, SameMachineRequestSetVMs: proxmoxOnA},
+			{Name: "node-b", MemoryFree: 0.9},
+		}
+	}
+
+	require.Equal(t, "node-a", s.Pick(twoNodes(0), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, "node-b", s.Pick(twoNodes(0), talosWorkers, "worker-2", nil).Name)
+
+	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", map[string]struct{}{"worker-1": {}})
+
+	require.Equal(t, "node-a", picked.Name)
+}
+
+func TestSchedulerExpiresStaleReservations(t *testing.T) {
+	now := time.Unix(0, 0).UTC()
+	s := provider.NewSchedulerWithClock(func() time.Time { return now }, time.Minute)
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 1.0},
+			{Name: "node-b", MemoryFree: 0.9},
+		}
+	}
+
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
+
+	now = now.Add(2 * time.Minute)
+
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
 }

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -188,7 +188,7 @@ func TestSchedulerSpreadsInFlightPlacements(t *testing.T) {
 	var picked []string
 
 	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
-		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, nil).Name)
+		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, 0, "spread", nil).Name)
 	}
 
 	require.ElementsMatch(t, []string{"node-a", "node-b", "node-c"}, picked)
@@ -204,10 +204,10 @@ func TestSchedulerReleasesMaterializedReservations(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, "node-a", s.Pick(twoNodes(0), talosWorkers, "worker-1", nil).Name)
-	require.Equal(t, "node-b", s.Pick(twoNodes(0), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, "node-a", s.Pick(twoNodes(0), talosWorkers, "worker-1", 0, "spread", nil).Name)
+	require.Equal(t, "node-b", s.Pick(twoNodes(0), talosWorkers, "worker-2", 0, "spread", nil).Name)
 
-	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", map[string]struct{}{"worker-1": {}})
+	picked := s.Pick(twoNodes(1), talosWorkers, "worker-3", 0, "spread", map[string]struct{}{"worker-1": {}})
 
 	require.Equal(t, "node-a", picked.Name)
 }
@@ -223,9 +223,66 @@ func TestSchedulerExpiresStaleReservations(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-1", nil).Name)
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-1", 0, "spread", nil).Name)
 
 	now = now.Add(2 * time.Minute)
 
-	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-2", nil).Name)
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-2", 0, "spread", nil).Name)
+}
+
+func TestSchedulerRoundRobinIgnoresMemory(t *testing.T) {
+	s := provider.NewScheduler()
+
+	// Memory order (c>b>a) is the inverse of name order, so a name-ordered
+	// result proves round-robin ignores free memory.
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", MemoryFree: 0.1},
+			{Name: "node-b", MemoryFree: 0.5},
+			{Name: "node-c", MemoryFree: 0.9},
+		}
+	}
+
+	var picked []string
+
+	for _, requestID := range []string{"worker-1", "worker-2", "worker-3"} {
+		picked = append(picked, s.Pick(nodes(), talosWorkers, requestID, 0, "round-robin", nil).Name)
+	}
+
+	require.Equal(t, []string{"node-a", "node-b", "node-c"}, picked)
+}
+
+func TestSchedulerFewerVMsBalancesTotalLoad(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := []provider.NodeStatus{
+		{Name: "node-a", TotalVMs: 9, SameMachineRequestSetVMs: 0, MemoryFree: 0.5},
+		{Name: "node-b", TotalVMs: 1, SameMachineRequestSetVMs: 3, MemoryFree: 0.5},
+	}
+
+	require.Equal(t, "node-b", s.Pick(nodes, talosWorkers, "worker-1", 0, "fewer-vms", nil).Name)
+}
+
+func TestSchedulerBinpackConsolidatesOntoNodesThatFit(t *testing.T) {
+	s := provider.NewScheduler()
+
+	nodes := func() []provider.NodeStatus {
+		return []provider.NodeStatus{
+			{Name: "node-a", FreeMem: 100},
+			{Name: "node-b", FreeMem: 50},
+		}
+	}
+
+	require.Equal(t, "node-b", s.Pick(nodes(), talosWorkers, "worker-1", 40, "binpack", nil).Name)
+	require.Equal(t, "node-a", s.Pick(nodes(), talosWorkers, "worker-2", 60, "binpack", nil).Name)
+}
+
+func TestParseStrategy(t *testing.T) {
+	for _, valid := range []string{"", "spread", "fewer-vms", "round-robin", "binpack"} {
+		_, err := provider.ParseStrategy(valid)
+		require.NoError(t, err)
+	}
+
+	_, err := provider.ParseStrategy("nonsense")
+	require.Error(t, err)
 }

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -5,6 +5,7 @@
 package provider_test
 
 import (
+	"net/netip"
 	"testing"
 	"time"
 
@@ -285,4 +286,38 @@ func TestParseStrategy(t *testing.T) {
 
 	_, err := provider.ParseStrategy("nonsense")
 	require.Error(t, err)
+}
+
+func TestParseIPAllocation(t *testing.T) {
+	for _, valid := range []string{"", "dhcp", "deterministic"} {
+		_, err := provider.ParseIPAllocation(valid)
+		require.NoError(t, err)
+	}
+
+	_, err := provider.ParseIPAllocation("bogus")
+	require.Error(t, err)
+}
+
+func TestAllocateIPDHCPReturnsNoAddress(t *testing.T) {
+	_, ok, err := provider.AllocateIP("dhcp", netip.MustParsePrefix("10.0.16.0/20"), 105)
+
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestAllocateIPDeterministicFromVMID(t *testing.T) {
+	addr, ok, err := provider.AllocateIP("deterministic", netip.MustParsePrefix("10.0.16.0/20"), 105)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "10.0.16.105", addr.String())
+}
+
+func TestBuildNetworkConfig(t *testing.T) {
+	cfg := provider.BuildNetworkConfig("10.0.16.105/20", "10.0.16.1", []string{"10.0.19.1", "10.0.19.2"})
+
+	require.Contains(t, cfg, "address: 10.0.16.105/20")
+	require.Contains(t, cfg, "gateway: 10.0.16.1")
+	require.Contains(t, cfg, "- 10.0.19.1")
+	require.Contains(t, cfg, "- 10.0.19.2")
 }

--- a/internal/pkg/provider/scheduler.go
+++ b/internal/pkg/provider/scheduler.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"sync"
+	"time"
+)
+
+// reservationTTL backstops placements whose VM never becomes visible in Proxmox.
+const reservationTTL = time.Hour
+
+type reservation struct {
+	at   time.Time
+	node string
+	set  string
+}
+
+// scheduler accounts for in-flight placements so concurrent VMs in a machine
+// request set spread across nodes instead of clumping onto one.
+type scheduler struct {
+	now          func() time.Time
+	reservations map[string]reservation
+	ttl          time.Duration
+	mu           sync.Mutex
+}
+
+func newScheduler() *scheduler {
+	return newSchedulerWithClock(time.Now, reservationTTL)
+}
+
+func newSchedulerWithClock(now func() time.Time, ttl time.Duration) *scheduler {
+	return &scheduler{
+		now:          now,
+		reservations: map[string]reservation{},
+		ttl:          ttl,
+	}
+}
+
+func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized map[string]struct{}) nodeStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+
+	for id, r := range s.reservations {
+		if _, done := materialized[id]; done || now.Sub(r.at) > s.ttl {
+			delete(s.reservations, id)
+		}
+	}
+
+	inFlight := map[string]int{}
+
+	for id, r := range s.reservations {
+		if id == requestID || r.set != set {
+			continue
+		}
+
+		inFlight[r.node]++
+	}
+
+	for i := range nodes {
+		nodes[i].SameMachineRequestSetVMs += inFlight[nodes[i].Name]
+	}
+
+	picked := pickNode(nodes)
+
+	s.reservations[requestID] = reservation{node: picked.Name, set: set, at: now}
+
+	return picked
+}

--- a/internal/pkg/provider/scheduler.go
+++ b/internal/pkg/provider/scheduler.go
@@ -5,21 +5,44 @@
 package provider
 
 import (
+	"cmp"
+	"fmt"
+	"slices"
 	"sync"
 	"time"
 )
 
-// reservationTTL backstops placements whose VM never becomes visible in Proxmox.
 const reservationTTL = time.Hour
 
+type placementStrategy string
+
+const (
+	strategySpread     placementStrategy = "spread"
+	strategyFewerVMs   placementStrategy = "fewer-vms"
+	strategyRoundRobin placementStrategy = "round-robin"
+	strategyBinpack    placementStrategy = "binpack"
+)
+
+func parseStrategy(s string) (placementStrategy, error) {
+	switch placementStrategy(s) {
+	case "", strategySpread:
+		return strategySpread, nil
+	case strategyFewerVMs, strategyRoundRobin, strategyBinpack:
+		return placementStrategy(s), nil
+	default:
+		return "", fmt.Errorf("unknown placement strategy %q", s)
+	}
+}
+
 type reservation struct {
-	at   time.Time
-	node string
-	set  string
+	at     time.Time
+	node   string
+	set    string
+	memory uint64
 }
 
 // scheduler accounts for in-flight placements so concurrent VMs in a machine
-// request set spread across nodes instead of clumping onto one.
+// request set are distributed by the chosen strategy instead of clumping.
 type scheduler struct {
 	now          func() time.Time
 	reservations map[string]reservation
@@ -39,7 +62,7 @@ func newSchedulerWithClock(now func() time.Time, ttl time.Duration) *scheduler {
 	}
 }
 
-func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized map[string]struct{}) nodeStatus {
+func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, memory uint64, strat placementStrategy, materialized map[string]struct{}) nodeStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -51,23 +74,95 @@ func (s *scheduler) pick(nodes []nodeStatus, set, requestID string, materialized
 		}
 	}
 
-	inFlight := map[string]int{}
+	byName := make(map[string]*nodeStatus, len(nodes))
+	for i := range nodes {
+		byName[nodes[i].Name] = &nodes[i]
+	}
 
 	for id, r := range s.reservations {
 		if id == requestID || r.set != set {
 			continue
 		}
 
-		inFlight[r.node]++
+		if ns, ok := byName[r.node]; ok {
+			applyReservation(strat, ns, r)
+		}
 	}
 
-	for i := range nodes {
-		nodes[i].SameMachineRequestSetVMs += inFlight[nodes[i].Name]
-	}
+	picked := selectNode(strat, nodes, memory)
 
-	picked := pickNode(nodes)
-
-	s.reservations[requestID] = reservation{node: picked.Name, set: set, at: now}
+	s.reservations[requestID] = reservation{node: picked.Name, set: set, memory: memory, at: now}
 
 	return picked
+}
+
+func applyReservation(strat placementStrategy, ns *nodeStatus, r reservation) {
+	switch strat {
+	case strategyFewerVMs:
+		ns.TotalVMs++
+	case strategyBinpack:
+		// FreeMem is unsigned; an over-reserved node ranks as full, not wrapped.
+		if ns.FreeMem >= r.memory {
+			ns.FreeMem -= r.memory
+		} else {
+			ns.FreeMem = 0
+		}
+	case strategySpread, strategyRoundRobin:
+		ns.SameMachineRequestSetVMs++
+	}
+}
+
+func selectNode(strat placementStrategy, nodes []nodeStatus, memory uint64) nodeStatus {
+	switch strat {
+	case strategyFewerVMs:
+		slices.SortFunc(nodes, func(a, b nodeStatus) int {
+			if c := cmp.Compare(a.TotalVMs, b.TotalVMs); c != 0 {
+				return c
+			}
+
+			return -cmp.Compare(a.MemoryFree, b.MemoryFree)
+		})
+
+		return nodes[0]
+	case strategyRoundRobin:
+		slices.SortFunc(nodes, func(a, b nodeStatus) int {
+			if c := cmp.Compare(a.SameMachineRequestSetVMs, b.SameMachineRequestSetVMs); c != 0 {
+				return c
+			}
+
+			return cmp.Compare(a.Name, b.Name)
+		})
+
+		return nodes[0]
+	case strategyBinpack:
+		return pickBinpack(nodes, memory)
+	case strategySpread:
+		return pickNode(nodes)
+	default:
+		return pickNode(nodes)
+	}
+}
+
+// Prefer the most-loaded node that still fits the requested memory, falling back
+// to the node with the most free memory when none fit.
+func pickBinpack(nodes []nodeStatus, memory uint64) nodeStatus {
+	slices.SortFunc(nodes, func(a, b nodeStatus) int {
+		aFits, bFits := a.FreeMem >= memory, b.FreeMem >= memory
+
+		if aFits != bFits {
+			if aFits {
+				return -1
+			}
+
+			return 1
+		}
+
+		if aFits {
+			return cmp.Compare(a.FreeMem, b.FreeMem)
+		}
+
+		return -cmp.Compare(a.FreeMem, b.FreeMem)
+	})
+
+	return nodes[0]
 }


### PR DESCRIPTION
The provisioner already knows which Proxmox host a VM landed on (the pickNode step, provision.go) but never surfaces that anywhere the cluster can see. There's no host-shaped node label today and nothing in this provider writes one.

The Omni client SDK already exposes provision.Context.CreateConfigPatch, a per-machine config patch hook, unused anywhere in this provider. This adds a labelHostNode step right after pickNode that calls it once the host is picked, writing:

machine:
  nodeLabels:
    proxmox.sidero.dev/node: <host>

This stays correct under any placement strategy, binpack, spread, or a pinned node, because it reads the actual host that got picked rather than assuming one from the machine class. A class-level Omni patch only works when a whole class is pinned to a single host; ours currently binpacks workers across multiple hosts, so a class-level label would be wrong for that pool.

Downstream use: cluster operators can key podAntiAffinity or nodeSelector rules off this label to keep replicas of a workload spread across physical hosts, not just Talos nodes.
